### PR TITLE
Ensure GDS-SSO / User compatibility

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,4 +1,8 @@
+require 'gds-sso/lint/user_spec'
+
 RSpec.describe User do
+  it_behaves_like 'a gds-sso user class'
+
   describe '#project_manager?' do
     it 'true when permissions contains "project_manager" permission' do
       expect(User.new(permissions: ['project_manager'])).to be_project_manager


### PR DESCRIPTION
Lints the `User` model to ensure compatibility with the `GDS::SSO::User`
module. This insulates us against changes to the GDS-SSO API.