### PR TITLE
Add pensionwise_admin access

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,10 @@ class User < ActiveRecord::Base
 
   serialize :permissions, Array
 
+  def pensionwise_admin?
+    permissions.include?('pensionwise_admin')
+  end
+
   def project_manager?
     permissions.include?('project_manager')
   end

--- a/app/policies/location_policy.rb
+++ b/app/policies/location_policy.rb
@@ -1,7 +1,9 @@
 class LocationPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
-      if user.project_manager?
+      if user.pensionwise_admin?
+        scope.all
+      elsif user.project_manager?
         scope.where(organisation: user.organisation_slug)
       else
         scope.none
@@ -10,7 +12,7 @@ class LocationPolicy < ApplicationPolicy
   end
 
   def update?
-    user.project_manager? && record.organisation == user.organisation_slug
+    user.pensionwise_admin? || project_manager_user_and_organisation?
   end
 
   def index?
@@ -19,5 +21,11 @@ class LocationPolicy < ApplicationPolicy
 
   def permitted_attributes
     [:hidden]
+  end
+
+  private
+
+  def project_manager_user_and_organisation?
+    (user.project_manager? && user.organisation_slug == record.organisation)
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -17,6 +17,10 @@ FactoryGirl.define do
       organisation_slug 'nicab'
     end
 
+    trait :pensionwise_admin do
+      permissions { %w(signin pensionwise_admin) }
+    end
+
     trait :project_manager do
       permissions { %w(signin project_manager) }
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,6 +3,17 @@ require 'gds-sso/lint/user_spec'
 RSpec.describe User do
   it_behaves_like 'a gds-sso user class'
 
+  describe '#pensionwise_admin?' do
+    it 'true when permissions contains "pensionwise_admin" permission' do
+      expect(User.new(permissions: ['pensionwise_admin'])).to be_pensionwise_admin
+    end
+
+    it 'false when permissions does not contains "admin" permission' do
+      expect(User.new(permissions: [])).not_to be_pensionwise_admin
+      expect(User.new(permissions: ['other'])).not_to be_pensionwise_admin
+    end
+  end
+
   describe '#project_manager?' do
     it 'true when permissions contains "project_manager" permission' do
       expect(User.new(permissions: ['project_manager'])).to be_project_manager


### PR DESCRIPTION
- based off 'pensionwise_admin' in permissions
- This allow users to see/edit locations across 
  organisations and is designed to be used by 
  pension wise staff only.