### PR TITLE
Ensure that editing a document creates a new version

### DIFF
--- a/app/controllers/admin/locations_controller.rb
+++ b/app/controllers/admin/locations_controller.rb
@@ -14,11 +14,13 @@ module Admin
     def update
       location = Location.find(params[:id])
       authorize location
-      if location.update_attributes(permitted_attributes(location))
-        flash[:notice] = "Successfully updated #{location.title}"
-      else
-        flash[:error] = "Error updating #{location.title}"
-      end
+
+      updater = UpdateLocation.new(uid: location.uid)
+      updater.update!(permitted_attributes(location))
+      flash[:notice] = "Successfully updated #{location.title}"
+      redirect_to_locations_directory(location)
+    rescue
+      flash[:error] = "Error updating #{location.title}"
       redirect_to_locations_directory(location)
     end
 

--- a/features/locations_admin_directory.feature
+++ b/features/locations_admin_directory.feature
@@ -42,7 +42,7 @@ Feature: Admin - Location Directory
 
   @javascript @noscript
   Scenario: an active location can be hidden in the location directory
-    Given a active location exists
+    Given an active location exists
     When I visit the locations admin directory
     And I hide the active location
     Then my locations should be hidden
@@ -54,3 +54,9 @@ Feature: Admin - Location Directory
     And I toggle the display hidden locations flag
     And I activate the hidden location
     Then my location should be active
+
+  Scenario: A new location version is created when the location is edited
+    Given an active location exists
+    When I visit the locations admin directory
+    And I hide the active location
+    Then I see that the location has a newer version

--- a/features/step_definitions/location_directory_steps.rb
+++ b/features/step_definitions/location_directory_steps.rb
@@ -79,7 +79,7 @@ Then(/^I should see the no locations available notice$/) do
   expect(@page).to have_notice
 end
 
-Given(/^a active location exists$/) do
+Given(/^an active location exists$/) do
   FactoryGirl.create(:user, :project_manager, :nicab)
   FactoryGirl.create(:location, :nicab)
 end
@@ -89,7 +89,8 @@ When(/^I hide the active location$/) do
 end
 
 Then(/^my locations should be hidden$/) do
-  expect(Location.first).to be_hidden
+  expect(Location.count).to eq(2)
+  expect(Location.current.first).to be_hidden
 end
 
 When(/^I activate the hidden location$/) do
@@ -97,5 +98,10 @@ When(/^I activate the hidden location$/) do
 end
 
 Then(/^my location should be active$/) do
-  expect(Location.first).not_to be_hidden
+  expect(Location.count).to eq(2)
+  expect(Location.current.first).not_to be_hidden
+end
+
+Then(/^I see that the location has a newer version$/) do
+  expect(Location.where(version: 2)).to exist
 end


### PR DESCRIPTION
avoid database request to get object and allow
direct retrieval of uid value from object.