### PR TITLE
Add active record id fields.

### DIFF
--- a/db/migrate/20160405090141_add_active_record_lookups_to_replace_curie.rb
+++ b/db/migrate/20160405090141_add_active_record_lookups_to_replace_curie.rb
@@ -1,0 +1,29 @@
+class AddActiveRecordLookupsToReplaceCurie < ActiveRecord::Migration
+  def up
+    add_reference :locations, :address
+    add_column :locations, :booking_location_uid, :string
+    add_index :locations, :booking_location_uid
+
+    Location.all.each do |location|
+      address_uid = extract_uid(location['address'])
+      booking_location_uid = extract_uid(location['booking_location'])
+
+      location.update_attributes!(
+        address_id: Address.find_by!(uid: address_uid).id,
+        booking_location_uid: booking_location_uid
+      )
+    end
+  end
+
+  def down
+    remove_column :locations, :address_id
+    remove_column :locations, :booking_location_uid
+  end
+
+  private
+
+  def extract_uid(field)
+    return nil if field.nil?
+    field.match(/^\[[^:]*:(.*)\]$/)[1]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160316145108) do
+ActiveRecord::Schema.define(version: 20160405090141) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,16 +37,20 @@ ActiveRecord::Schema.define(version: 20160316145108) do
     t.string   "title"
     t.string   "address"
     t.string   "phone"
-    t.string   "hours",            limit: 500
+    t.string   "hours",                limit: 500
     t.string   "booking_location"
-    t.string   "state",                        default: "pending"
+    t.string   "state",                            default: "pending"
     t.datetime "closed_at"
     t.integer  "version"
     t.jsonb    "raw"
-    t.datetime "created_at",                                       null: false
-    t.datetime "updated_at",                                       null: false
-    t.boolean  "hidden",                       default: false
+    t.datetime "created_at",                                           null: false
+    t.datetime "updated_at",                                           null: false
+    t.boolean  "hidden",                           default: false
+    t.integer  "address_id"
+    t.string   "booking_location_uid"
   end
+
+  add_index "locations", ["booking_location_uid"], name: "index_locations_on_booking_location_uid", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "name"


### PR DESCRIPTION
Please note that we are using `booking_location_uid` instead of `booking_location_id`

This is so we can get the latest details of the booking location.