### PR TITLE
Display errors within the form when editing

### DIFF
--- a/app/assets/stylesheets/admin/application.scss
+++ b/app/assets/stylesheets/admin/application.scss
@@ -3,6 +3,8 @@
 @import "./lib/variables";
 @import "./helpers/contain-floats";
 
+@import "./components/error-summary";
+@import "./components/form-group";
 @import "./components/label";
 @import "./components/location-details-table";
 @import "./components/pagination-atoz";

--- a/app/assets/stylesheets/admin/components/_error-summary.scss
+++ b/app/assets/stylesheets/admin/components/_error-summary.scss
@@ -1,0 +1,26 @@
+.error-summary {
+
+  border: 4px solid $form-error-color;
+  margin-top: 15px;
+  margin-bottom: 15px;
+  padding: 15px 10px;
+
+  .error-summary__heading {
+    margin-top: 0;
+  }
+
+  .error-summary__list {
+    padding-left: 0;
+  }
+
+  .error-summary__list-item {
+    list-style-type: disc;
+    margin-left: 20px;
+  }
+
+  .error-summary__link {
+    color: $form-error-color;
+    font-weight: bold;
+    text-decoration: underline;
+  }
+}

--- a/app/assets/stylesheets/admin/components/_form-group.scss
+++ b/app/assets/stylesheets/admin/components/_form-group.scss
@@ -1,0 +1,17 @@
+.form-group--error {
+  border-left: 5px solid $form-error-color;
+  padding-left: 15px;
+
+  // scss-lint:disable SelectorFormat
+  .field_with_errors label { // override bootstrap style
+    color: $form-default-text-color;
+  }
+  // scss-lint:enable SelectorFormat
+
+  .form-group__error-message {
+    color: $form-error-color;
+    font-weight: bold;
+    padding: 5px 0 7px;
+    display: block;
+  }
+}

--- a/app/assets/stylesheets/admin/lib/_variables.scss
+++ b/app/assets/stylesheets/admin/lib/_variables.scss
@@ -19,6 +19,9 @@ $color-green-jungle: #00385d;
 $color-medium-red-violet: #b0348b;
 $color-razmatazz: #e50050;
 
+$color-apple-blossom: #a94442;
+$color-mine-shaft: #333;
+
 //color for pagination
 $active-letter-background: $color-white;
 $active-letter-background--hover: $color-grey-mercury;
@@ -27,6 +30,9 @@ $active-letter-color: $color-blue-endeavour;
 
 $disabled-letter-background: $color-white;
 $disabled-letter-text: $color-grey-silver-sand;
+
+$form-error-color: $color-apple-blossom;
+$form-default-text-color: $color-mine-shaft;
 
 $selected-letter-background: $color-blue-endeavour;
 $selected-letter-text: $color-white;

--- a/app/controllers/admin/locations_controller.rb
+++ b/app/controllers/admin/locations_controller.rb
@@ -22,12 +22,13 @@ module Admin
 
     def update
       updater = UpdateLocation.new(location: @location, user: current_user)
-      updater.update!(permitted_attributes(@location))
-      flash[:notice] = "Successfully updated #{@location.title}"
-      redirect_to admin_locations_path(location_params)
-    rescue
-      flash[:error] = "Error updating #{@location.title}"
-      redirect_to admin_locations_path(location_params)
+      @location = updater.update(permitted_attributes(@location))
+      if @location.new_record?
+        @booking_locations = policy_scope(Location.current.where(booking_location_uid: nil))
+        render :edit
+      else
+        redirect_to admin_location_path(@location.uid), notice: "Successfully updated #{@location.title}"
+      end
     end
 
     private
@@ -35,14 +36,6 @@ module Admin
     def set_autherised_location
       @location ||= Location.current.find_by!(uid: params[:id])
       authorize @location
-    end
-
-    def location_params
-      {
-        letter: @location.title[0],
-        display_hidden: display_hidden?,
-        display_active: display_active?
-      }
     end
 
     def hidden_flags

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,4 +13,12 @@ module ApplicationHelper
       flash_type.to_s
     end
   end
+
+  def error_messages_for(*objects)
+    object_names = objects.map { |object| object.class.to_s.underscore }
+    objects
+      .map { |object| object.errors.messages.reject { |attribute, _| object_names.include?(attribute.to_s) } }
+      .inject(&:merge)
+      .sort_by(&:first)
+  end
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,7 +1,7 @@
 class Location < ActiveRecord::Base
   EDIT_FIELDS = %w(address_id booking_location_uid hidden hours organisation phone title uid).freeze
 
-  belongs_to :address
+  belongs_to :address, validate: true
   belongs_to :booking_location, -> { current },
              foreign_key: :booking_location_uid,
              primary_key: :uid,

--- a/app/views/admin/locations/_error.html.erb
+++ b/app/views/admin/locations/_error.html.erb
@@ -1,0 +1,3 @@
+<% if error_messages.any? %>
+  <%= simple_format error_messages.join("\n"), { class: 'form-group__error-message' }, wrapper_tag: 'span' %>
+<% end %>

--- a/app/views/admin/locations/_form.html.erb
+++ b/app/views/admin/locations/_form.html.erb
@@ -1,46 +1,77 @@
-<%= form_for location, url: admin_location_path do |f| %>
-  <div class="form-group">
+<%= form_for location, url: admin_location_path, method: 'put' do |f| %>
+  <% if location.errors.any? %>
+
+    <div class="row">
+      <div class="col-md-6">
+        <div class="error-summary t-errors ">
+          <h2 class="error-summary__heading">There's a problem</h2>
+          <ul class="error-summary__list">
+            <% error_messages_for(location, location.address).each do |attribute, attribute_errors| %>
+              <% attribute_errors.each do |attribute_error| %>
+                <li class="error-summary__list-item t-error-message">
+                  <a class="error-summary__link" href="#<%= attribute %>"><%= sanitize(attribute_error, :tags => []) %></a>
+                </li>
+              <% end %>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
+  <div class="form-group <%= 'form-group--error' if f.object.errors[:title].any? %>" id="title">
     <%= f.label :title %>
+    <%= render 'error', error_messages: location.errors[:title] %>
     <%= f.text_field :title, class: 'input-md-3 form-control t-location-title' %>
   </div>
 
   <%= f.fields_for(:address, location.address) do |a| %>
-    <div class="form-group">
-      <%= a.label :address_line_1, 'Address' %>
-      <%= a.text_field :address_line_1, class: 'input-md-3 form-control t-address-line-1' %>
+    <div class="<%= 'form-group--error' if a.object.errors[:address_line_1].any? %>">
+      <div class="form-group" id="address_line_1">
+        <%= a.label :address_line_1, 'Address' %>
+        <%= render 'error', error_messages: a.object.errors[:address_line_1] %>
+        <%= a.text_field :address_line_1, class: 'input-md-3 form-control t-address-line-1' %>
+      </div>
+
+      <div class="form-group <%= 'form-group--error' if a.object.errors[:address_line_2].any? %>" id="address_line_2">
+        <%= render 'error', error_messages: location.address.errors[:address_line_2] %>
+        <%= a.text_field :address_line_2, class: 'input-md-3 form-control t-address-line-2' %>
+      </div>
+
+      <div class="form-group <%= 'form-group--error' if a.object.errors[:address_line_3].any? %>" id="address_line_3">
+        <%= render 'error', error_messages: location.address.errors[:address_line_3] %>
+        <%= a.text_field :address_line_3, class: 'input-md-3 form-control t-address-line-3' %>
+      </div>
     </div>
 
-    <div class="form-group">
-      <%= a.text_field :address_line_2, class: 'input-md-3 form-control t-address-line-2' %>
-    </div>
-
-    <div class="form-group">
-      <%= a.text_field :address_line_3, class: 'input-md-3 form-control t-address-line-3' %>
-    </div>
-
-    <div class="form-group">
+    <div class="form-group <%= 'form-group--error' if a.object.errors[:town].any? %>" id="town">
       <%= a.label :town %>
+      <%= render 'error', error_messages: location.address.errors[:town] %>
       <%= a.text_field :town, class: 'input-md-3 form-control t-town' %>
     </div>
 
-    <div class="form-group">
+    <div class="form-group <%= 'form-group--error' if a.object.errors[:county].any? %>" id="county">
       <%= a.label :county %>
+      <%= render 'error', error_messages: location.address.errors[:county] %>
       <%= a.text_field :county, class: 'input-md-3 form-control t-county' %>
     </div>
 
-    <div class="form-group">
+    <div class="form-group <%= 'form-group--error' if a.object.errors[:postcode].any? %>" id="postcode">
       <%= a.label :postcode %>
+      <%= render 'error', error_messages: location.address.errors[:postcode] %>
       <%= a.text_field :postcode, class: 'input-md-2 form-control t-postcode' %>
     </div>
   <% end %>
 
-  <div class="form-group">
+  <div class="form-group <%= 'form-group--error' if f.object.errors[:hours].any? %>" id="hours">
     <%= f.label :hours, 'Booking hours' %>
+    <%= render 'error', error_messages: location.errors[:hours] %>
     <%= f.text_area :hours, class: 'input-md-3 form-control t-booking-hours' %>
   </div>
 
-  <div class="form-group">
+  <div class="form-group <%= 'form-group--error' if f.object.errors[:booking_location].any? %>" id="booking_location">
     <%= f.label :booking_location_uid, 'Booking location:' %>
+    <%= render 'error', error_messages: location.errors[:booking_location] %>
     <%= f.collection_select(
           :booking_location_uid,
           @booking_locations,
@@ -52,13 +83,15 @@
     %>
   </div>
 
-  <div class="form-group">
+  <div class="form-group <%= 'form-group--error' if f.object.errors[:phone].any? %>" id="phone">
     <%= f.label :phone, 'Telephone number' %>
+    <%= render 'error', error_messages: location.errors[:phone] %>
     <%= f.text_field :phone, class: 'input-md-3 form-control', disabled: true %>
   </div>
 
-  <div class="form-group t-visibility">
+  <div class="form-group t-visibility <%= 'form-group--error' if f.object.errors[:hidden].any? %>" id="hidden">
     <%= f.label :hidden, 'Visibility', class: 'block' %><br/>
+    <%= render 'error', error_messages: location.errors[:hidden] %>
     <%= hidden_field_tag :display_hidden, params[:display_hidden] %>
     <%= hidden_field_tag :display_active, params[:display_active] %>
     <%= f.radio_button :hidden, false, class: 'l-location-status__checkbox', id: "location_hidden_false_#{location.id}" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,4 +20,18 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  activerecord:
+    errors:
+      models:
+        location:
+          attributes:
+            title:
+              blank: Please enter the title
+        address:
+          attributes:
+            postcode:
+              blank: Please enter the postcode
+              non_uk: We were unable to find that postcode in the UK
+              geocoding_error: We were unable to find a point in the UK with that postcode
+            address_line_1:
+              blank: Please enter the first line of the address

--- a/features/admin_location.feature
+++ b/features/admin_location.feature
@@ -47,3 +47,9 @@ Feature: Admin - Location Directory
     When I visit the "Apples" location
     And I set the locations "location_title" field to "Green delicious"
     Then I see that the location has a newer version
+
+  Scenario: When an update fails
+    Given a location exists called "Apples"
+    When I visit the "Apples" location
+    And I set the locations "postcode" field to ""
+    Then I should see an error message for "postcode"

--- a/features/pages/admin_edit_location_page.rb
+++ b/features/pages/admin_edit_location_page.rb
@@ -14,4 +14,10 @@ class AdminEditLocationPage < SitePrism::Page
   element :postcode, '.t-postcode'
 
   element :save_button, '.t-save-button'
+
+  elements :errors, '.t-error-message'
+
+  def error_messages
+    errors.map(&:text)
+  end
 end

--- a/features/step_definitions/admin/edited_locations_steps.rb
+++ b/features/step_definitions/admin/edited_locations_steps.rb
@@ -2,7 +2,8 @@ Given(/^a location exists that has been hidden$/) do
   user = FactoryGirl.create(:user, :pensionwise_admin)
   location = FactoryGirl.create(:location, :nicab, created_at: 1.month.ago)
   updater = UpdateLocation.new(location: location, user: user)
-  updater.update!(hidden: true)
+  params = { 'hidden' => 'true' }
+  updater.update(params)
 end
 
 When(/^I view the edited locations page$/) do
@@ -26,8 +27,10 @@ Given(/^a location exists that has been hidden and then made visible$/) do
   user = FactoryGirl.create(:user, :pensionwise_admin)
   location = FactoryGirl.create(:location, :nicab, created_at: 1.month.ago)
   updater = UpdateLocation.new(location: location, user: user)
-  updater.update!(hidden: true)
-  updater.update!(hidden: false)
+  params = { 'hidden' => 'true' }
+  updater.update(params)
+  params = { 'hidden' => 'false' }
+  updater.update(params)
 end
 
 Given(/^a location exists that was hidden yesterday$/) do
@@ -35,7 +38,8 @@ Given(/^a location exists that was hidden yesterday$/) do
   location = FactoryGirl.create(:location, :nicab, created_at: 1.month.ago)
   updater = UpdateLocation.new(location: location, user: user)
   travel_to(Time.zone.yesterday) do
-    updater.update!(hidden: true)
+    params = { hidden: true }.with_indifferent_access
+    updater.update(params)
   end
 end
 
@@ -47,5 +51,6 @@ Given(/^a location exists that with a address edit$/) do
   user = FactoryGirl.create(:user, :pensionwise_admin)
   location = FactoryGirl.create(:location, :nicab, :one_line_address, created_at: 1.month.ago)
   updater = UpdateLocation.new(location: location, user: user)
-  updater.update!(address: { address_line_1: 'My New Address', postcode: 'UB9 4LH' })
+  params = { address: { address_line_1: 'My New Address', postcode: 'UB9 4LH' } }.with_indifferent_access
+  updater.update(params)
 end

--- a/features/step_definitions/admin/location_steps.rb
+++ b/features/step_definitions/admin/location_steps.rb
@@ -53,6 +53,11 @@ Then(/^the "([^"]*)" location address has been updated to have "([^"]*)" set to 
   expect(edited_fields).to match_edits([{ field: 'address', new_value: value }])
 end
 
+Then(/^I should see an error message for "([^"]*)"$/) do |field|
+  edit_page = AdminEditLocationPage.new
+  expect(edit_page.error_messages.first).to match(field)
+end
+
 module LocationTestHelper
   FIELD_NAME_MAP = { 'location_title' => 'title', 'booking_hours' => 'hours' }.freeze
 

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Address do
 
       it 'does not save the record' do
         address = Address.create(postcode: 'AA1 2BB', address_line_1: 'line 1')
-        expect(address.errors.full_messages).to eq(['Point geocoder lookup failed'])
+        expect(address).to be_new_record
       end
     end
   end
@@ -71,18 +71,36 @@ RSpec.describe Address do
     end
 
     context 'when postcode is present' do
-      let(:params) { { postcode: 'AA1 2BB' } }
+      context 'and is a valid UK postcode' do
+        let(:params) { { postcode: 'AA1 2BB' } }
 
-      it 'raises a validation around geocoding' do
-        expect(subject.errors.full_messages).to include('Point geocoder lookup failed')
+        it 'raises a validation around geocoding' do
+          expect(subject.errors).to be_added(:postcode, :geocoding_error)
+        end
+      end
+
+      context 'and is not a valid UK postcode' do
+        let(:params) { { postcode: 'APPLES' } }
+
+        it 'raise a validation around postcode not being valid' do
+          expect(subject.errors).to be_added(:postcode, :non_uk)
+        end
+
+        it 'it does not raise a validation around geocoding' do
+          expect(subject.errors).not_to be_added(:postcode, :geocoding_error)
+        end
       end
     end
 
     context 'when postcode is not present' do
       let(:params) { { postcode: nil } }
 
+      it 'raise a validation around postcode is blank' do
+        expect(subject.errors).to be_added(:postcode, :blank)
+      end
+
       it 'it does not raise a validation around geocoding' do
-        expect(subject.errors.full_messages).not_to include('Point geocoder lookup failed')
+        expect(subject.errors).not_to be_added(:postcode, :geocoding_error)
       end
     end
   end

--- a/spec/services/update_location_spec.rb
+++ b/spec/services/update_location_spec.rb
@@ -19,18 +19,18 @@ RSpec.describe UpdateLocation do
         state: 'current',
         version: 1,
         editor: other_user
-      }
+      }.with_indifferent_access
     end
 
     context 'when an existing location would be unchanged by the update' do
       it 'does not create new location version' do
-        expect { subject.update!(params) }.not_to change { Location.count }
+        expect { subject.update(params) }.not_to change { Location.count }
       end
 
       it 'ignores difference in versioning fields' do
         params[:created_at] = 10.days.ago
         params[:updated_at] = 10.days.ago
-        expect { subject.update!(params) }.not_to change { Location.count }
+        expect { subject.update(params) }.not_to change { Location.count }
       end
     end
 
@@ -41,7 +41,7 @@ RSpec.describe UpdateLocation do
         end
 
         it 'does not update the existing locations state' do
-          subject.update!(params) rescue nil
+          subject.update(params) rescue nil
           expect(location.reload.state).to eq('current')
         end
       end
@@ -50,49 +50,57 @@ RSpec.describe UpdateLocation do
         let(:update_params) { params.merge(title: 'New title') }
 
         it 'creates a new location entry in the database' do
-          expect { subject.update!(update_params) }.to change { Location.count }.by(1)
+          expect { subject.update(update_params) }.to change { Location.count }.by(1)
         end
 
         it 'change the state on the existing location to "old"' do
-          subject.update!(update_params)
+          subject.update(update_params)
           expect(location.reload.state).to eq('old')
         end
 
         it 'sets the editor to the passed in user' do
-          expect(subject.update!(update_params).editor).to eq(user)
+          expect(subject.update(update_params).editor).to eq(user)
         end
 
         it 'create a new location with the params' do
-          expect { subject.update!(update_params) }.to change { Location.count }.by(1)
+          expect { subject.update(update_params) }.to change { Location.count }.by(1)
         end
 
         it 'does not creates a new address entry in the database' do
-          expect { subject.update!(update_params) }.not_to change { Address.count }
+          expect { subject.update(update_params) }.not_to change { Address.count }
         end
 
         it 'set the new locations state to current' do
-          expect(subject.update!(update_params).state).to eq('current')
+          expect(subject.update(update_params).state).to eq('current')
         end
 
         it 'set the new locations version to one greater than the existing location' do
-          expect(subject.update!(update_params).version).to eq(location.version + 1)
+          expect(subject.update(update_params).version).to eq(location.version + 1)
         end
 
         context 'update only receives a subset of parameters' do
-          let(:update_params) { { hidden: true } }
+          let(:update_params) { { hidden: true }.with_indifferent_access }
 
           it 'create a new location with the params' do
-            expect { subject.update!(update_params) }.to change { Location.count }.by(1)
+            expect { subject.update(update_params) }.to change { Location.count }.by(1)
           end
 
           it 'uses copies un-modified attributes from the previous version' do
-            expect(subject.update!(update_params).title).to eq(location.title)
+            expect(subject.update(update_params).title).to eq(location.title)
           end
         end
       end
 
       context 'and the address field is changed' do
-        let(:update_params) { { address: { town: 'New town', postcode: 'AA1 2BB', address_line_1: 'Hope' } } }
+        let(:update_params) do
+          {
+            address: {
+              town: 'New town',
+              postcode: 'AA1 2BB',
+              address_line_1: 'Hope'
+            }
+          }.with_indifferent_access
+        end
         let(:geocode) { instance_double('PostcodeGeocoder', valid?: true, coordinates: [-2.000, 52.000]) }
 
         before do
@@ -100,15 +108,34 @@ RSpec.describe UpdateLocation do
         end
 
         it 'creates a new location entry in the database' do
-          expect { subject.update!(update_params) }.to change { Location.count }.by(1)
+          expect { subject.update(update_params) }.to change { Location.count }.by(1)
         end
 
         it 'creates a new address entry in the database' do
-          expect { subject.update!(update_params) }.to change { Address.count }.by(1)
+          expect { subject.update(update_params) }.to change { Address.count }.by(1)
         end
 
         it 'does copy un-modified address parameters' do
-          expect(subject.update!(update_params).address.postcode).not_to eq(location.address.postcode)
+          expect(subject.update(update_params).address.postcode).not_to eq(location.address.postcode)
+        end
+
+        describe 'to an invalid address' do
+          let(:geocode) { instance_double('PostcodeGeocoder', valid?: false) }
+
+          it 'fails the update' do
+            expect(subject.update(update_params)).not_to be_valid
+          end
+
+          it 'includes has access to the address error messages' do
+            new_location = subject.update(update_params)
+            expect(new_location.errors).to be_added(:address, :invalid)
+            expect(new_location.address.errors).to be_added(:postcode, :geocoding_error)
+          end
+
+          it 'does not change the state on the old location' do
+            subject.update(update_params)
+            expect(location.reload.state).to eq('current')
+          end
         end
       end
     end


### PR DESCRIPTION
Previously a failure during the editing process resulted the user being sent back to the index screen and an alert being displayed. 

This did not lend itself to understanding or correcting the error, it also didn't allow the user to review the values they had entered.

This update will re-render the edit page, with error messages, similar to the summary_generator.