### PR TITLE
Allow hidden locations to be returned in locations.json

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -2,7 +2,11 @@ class LocationsController < ApplicationController
   def index
     expires_in Rails.application.config.cache_max_age, public: true
 
-    @locations = Location.includes(:address, :booking_location).where(state: 'current', hidden: false)
+    @locations = Location.current.includes(:address, :booking_location)
+
+    unless params[:include_hidden_locations]
+      @locations = @locations.where(hidden: false)
+    end
 
     respond_to do |format|
       format.json

--- a/spec/controllers/locations_controller_spec.rb
+++ b/spec/controllers/locations_controller_spec.rb
@@ -2,9 +2,8 @@ require 'rails_helper'
 
 RSpec.describe LocationsController do
   describe '#index' do
-    before do
-      FactoryGirl.create(:location, uid: '25de9301-50b5-49ba-a5da-7f40a2fcfe29')
-    end
+    let!(:active_location) { FactoryGirl.create(:location, uid: '25de9301-50b5-49ba-a5da-7f40a2fcfe29') }
+    let!(:hidden_location) { FactoryGirl.create(:location, uid: '25de9301-50b5-49ba-a5da-7f40a2fcfe29', hidden: true) }
 
     it 'renders the location as JSON' do
       get :index, format: 'json'
@@ -13,6 +12,18 @@ RSpec.describe LocationsController do
 
     it 'requires JSON format to be passed in' do
       expect { get :index }.to raise_error(ActionController::UnknownFormat)
+    end
+
+    it 'does not include hidden locations by default' do
+      get :index, format: 'json'
+      expect(assigns(:locations)).to match_array([active_location])
+    end
+
+    context 'when include_hidden_locations flag is set' do
+      it 'includes hidden location' do
+        get :index, format: 'json', include_hidden_locations: 'true'
+        expect(assigns(:locations)).to match_array([active_location, hidden_location])
+      end
     end
   end
 end


### PR DESCRIPTION
Add a flag to allow hidden locations to be included
in locations.json. This is required to get all locations
for the data platform.

Note: This is specifically to ensure we get Caerphilly
in the feed which is a hidden location as it does 
not have appointments, it is a call centre only.