### PR TITLE
Exclude hidden locations from booking locations

### DIFF
--- a/app/controllers/admin/edited_locations_controller.rb
+++ b/app/controllers/admin/edited_locations_controller.rb
@@ -3,7 +3,7 @@ module Admin
     def index
       @date = Date.parse(params[:date] || Time.zone.today.to_s)
       authorize Location
-      scope = Location.where(created_at: @date...@date + 1)
+      scope = Location.between(@date, @date + 1)
 
       @edited_locations = EditedLocation.all(policy_scope(scope))
     end

--- a/app/controllers/admin/locations_controller.rb
+++ b/app/controllers/admin/locations_controller.rb
@@ -4,7 +4,7 @@ module Admin
 
     def index
       authorize Location
-      scope = Location.current.where(hidden: hidden_flags)
+      scope = Location.with_visibility_flags(hidden_flags)
 
       @locations, @sorting_params = policy_scope(scope).alpha_paginate(
         params[:letter],
@@ -17,14 +17,14 @@ module Admin
     end
 
     def edit
-      @booking_locations = policy_scope(Location.current.where(booking_location_uid: nil))
+      @booking_locations = policy_scope(Location.booking_locations)
     end
 
     def update
       updater = UpdateLocation.new(location: @location, user: current_user)
       @location = updater.update(permitted_attributes(@location))
       if @location.new_record?
-        @booking_locations = policy_scope(Location.current.where(booking_location_uid: nil))
+        @booking_locations = policy_scope(Location.booking_locations)
         render :edit
       else
         redirect_to admin_location_path(@location.uid), notice: "Successfully updated #{@location.title}"

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -2,11 +2,7 @@ class LocationsController < ApplicationController
   def index
     expires_in Rails.application.config.cache_max_age, public: true
 
-    @locations = Location.current.includes(:address, :booking_location)
-
-    unless params[:include_hidden_locations]
-      @locations = @locations.where(hidden: false)
-    end
+    @locations = Location.externally_visible(include_hidden_locations: params[:include_hidden_locations])
 
     respond_to do |format|
       format.json

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -19,6 +19,27 @@ class Location < ActiveRecord::Base
 
   default_scope -> { order(:title) }
   scope :current, -> { where(state: 'current') }
+  scope :active, -> { where(hidden: false) }
+
+  class << self
+    def between(start_time, end_time)
+      where(created_at: start_time...end_time)
+    end
+
+    def booking_locations
+      current.active.where(booking_location_uid: nil)
+    end
+
+    def externally_visible(include_hidden_locations:)
+      scope = current.includes(:address, :booking_location)
+      scope = scope.active unless include_hidden_locations
+      scope
+    end
+
+    def with_visibility_flags(hidden_flags)
+      current.where(hidden: hidden_flags)
+    end
+  end
 
   def initialize(*args)
     super

--- a/spec/controllers/locations_controller_spec.rb
+++ b/spec/controllers/locations_controller_spec.rb
@@ -2,8 +2,10 @@ require 'rails_helper'
 
 RSpec.describe LocationsController do
   describe '#index' do
-    let!(:active_location) { FactoryGirl.create(:location, uid: '25de9301-50b5-49ba-a5da-7f40a2fcfe29') }
-    let!(:hidden_location) { FactoryGirl.create(:location, uid: '25de9301-50b5-49ba-a5da-7f40a2fcfe29', hidden: true) }
+    let(:externally_visible) { double }
+    before do
+      allow(Location).to receive(:externally_visible).and_return(externally_visible)
+    end
 
     it 'renders the location as JSON' do
       get :index, format: 'json'
@@ -14,16 +16,14 @@ RSpec.describe LocationsController do
       expect { get :index }.to raise_error(ActionController::UnknownFormat)
     end
 
-    it 'does not include hidden locations by default' do
+    it 'assigns the result of externally visible' do
       get :index, format: 'json'
-      expect(assigns(:locations)).to match_array([active_location])
+      expect(assigns(:locations)).to eq(externally_visible)
     end
 
-    context 'when include_hidden_locations flag is set' do
-      it 'includes hidden location' do
-        get :index, format: 'json', include_hidden_locations: 'true'
-        expect(assigns(:locations)).to match_array([active_location, hidden_location])
-      end
+    it 'passes the include_hidden_locations flag to Location.external_visible' do
+      expect(Location).to receive(:externally_visible).with(include_hidden_locations: 'true')
+      get :index, format: 'json', include_hidden_locations: 'true'
     end
   end
 end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Location do
+  describe '.externally_visible' do
+    let!(:active_location) { FactoryGirl.create(:location, uid: '25de9301-50b5-49ba-a5da-7f40a2fcfe29') }
+    let!(:hidden_location) { FactoryGirl.create(:location, uid: '25de9301-50b5-49ba-a5da-7f40a2fcfe29', hidden: true) }
+
+    it 'includes hidden locations when include_hidden_locations is true' do
+      locations = Location.externally_visible(include_hidden_locations: true)
+      expect(locations).to match_array([active_location, hidden_location])
+    end
+
+    it 'excludes hidden locations when include_hidden_locations is false' do
+      locations = Location.externally_visible(include_hidden_locations: false)
+      expect(locations).to match_array([active_location])
+    end
+  end
+end


### PR DESCRIPTION
This corrects a bug that allowed hidden booking locations to appear in the edit drop down.

It also implemented the suggestion from @benlovell regarding moving logic from the controller to the model when it can to chained scopes and where conditions
