### PR TITLE
Warn on destructive migrations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'puma'
 
 gem 'alphabetical_paginate'
 gem 'bugsnag'
+gem 'deprecated_columns'
 gem 'gaffe'
 gem 'gds-sso'
 gem 'geocoder'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,8 @@ GEM
     cucumber-wire (0.0.1)
     database_cleaner (1.5.1)
     debug_inspector (0.0.2)
+    deprecated_columns (0.1.0)
+      rails (>= 4.0)
     diff-lcs (1.2.5)
     dotenv (2.1.0)
     dotenv-rails (2.1.0)
@@ -315,6 +317,7 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   cucumber-rails
   database_cleaner
+  deprecated_columns
   dotenv-rails
   factory_girl_rails
   foreman

--- a/db/migrate/20160405145153_add_users_to_locations.rb
+++ b/db/migrate/20160405145153_add_users_to_locations.rb
@@ -2,15 +2,17 @@ class AddUsersToLocations < ActiveRecord::Migration
   def up
     add_reference :locations, :editor, references: :user
 
-    user = User.find_by!(email: 'david.henry@pensionwise.gov.uk')
+    if defined?(User)
+      user = User.find_by!(email: 'david.henry@pensionwise.gov.uk')
 
-    initial_deploy_date = Date.new(2016, 4, 3)
+      initial_deploy_date = Date.new(2016, 4, 3)
 
-    Location.where(['created_at < ?', initial_deploy_date]).update_all(editor_id: user.id)
+      Location.where(['created_at < ?', initial_deploy_date]).update_all(editor_id: user.id)
 
-    Location.where(['created_at >= ?', initial_deploy_date]).each do |location|
-      location.editor_id = User.find_by!(organisation_slug: location.organisation).id
-      location.save!
+      Location.where(['created_at >= ?', initial_deploy_date]).each do |location|
+        location.editor_id = User.find_by!(organisation_slug: location.organisation).id
+        location.save!
+      end
     end
   end
 


### PR DESCRIPTION
Since we use preloaded dynos we should actively highlight destructive schema
changes. Loading the `deprecated_columns` gem will warn for migrations with
persisted attributes not marked with the `deprecated_columns` macro.

Running the migrations from scratch caused issues with undefined model classes,
particularly `User` being an anachronism. I've simply wrapped the non-DDL parts
of the offending migration in a `defined?` check.