### PR TITLE
Replace switchboard application

### DIFF
--- a/app/controllers/twilios_controller.rb
+++ b/app/controllers/twilios_controller.rb
@@ -1,0 +1,10 @@
+class TwiliosController < ApplicationController
+  def show
+    if params[:To].blank?
+      head :bad_request
+    else
+      @twilio_redirection = TwilioRedirection.for(params[:To])
+      @twilio_redirection || head(:not_found)
+    end
+  end
+end

--- a/app/decorators/address_field_decorator.rb
+++ b/app/decorators/address_field_decorator.rb
@@ -11,6 +11,7 @@ class AddressFieldDecorator < SimpleDelegator
 
   def wrap(value)
     return '' if value.nil?
+
     value.to_a.join('<br/>').html_safe
   end
 end

--- a/app/decorators/booking_location_field_decorator.rb
+++ b/app/decorators/booking_location_field_decorator.rb
@@ -11,6 +11,7 @@ class BookingLocationFieldDecorator < SimpleDelegator
 
   def wrap(value)
     return '' if value.nil?
+
     value.title
   end
 end

--- a/app/decorators/visibility_field_decorator.rb
+++ b/app/decorators/visibility_field_decorator.rb
@@ -15,6 +15,7 @@ class VisibilityFieldDecorator < SimpleDelegator
 
   def wrap(value)
     return '' if value.nil?
+
     value ? 'Hidden' : 'Active'
   end
 end

--- a/app/forms/locations_directory.rb
+++ b/app/forms/locations_directory.rb
@@ -37,6 +37,7 @@ class LocationsDirectory
   def normalize_boolean_or_default(value, default)
     return default if value.nil?
     return false if %w(false 0).include?(value)
+
     value.present?
   end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -45,8 +45,10 @@ class Address < ActiveRecord::Base
 
   def set_point_from_postcode
     return if postcode.blank? || point.present?
+
     geocode = PostcodeGeocoder.new(postcode)
     return unless geocode.valid?
+
     self.point = {
       type: 'Point',
       coordinates: geocode.coordinates

--- a/app/models/call_centre.rb
+++ b/app/models/call_centre.rb
@@ -1,10 +1,8 @@
 class CallCentre < ActiveRecord::Base
-  PHONE_NUMBER_REGEXP = /\A\+44\d{9,10}\z/
-
   validates :uid, presence: true
   validates :purpose, presence: true
-  validates :phone, format: PHONE_NUMBER_REGEXP
+  validates :phone, uk_phone_number: true
   validates :twilio_number,
             uniqueness: true,
-            format: PHONE_NUMBER_REGEXP
+            uk_phone_number: true
 end

--- a/app/models/twilio_redirection.rb
+++ b/app/models/twilio_redirection.rb
@@ -21,6 +21,7 @@ class TwilioRedirection
 
     def phone_options
       return {} if @location.extension.blank?
+
       { sendDigits: @location.extension }
     end
   end

--- a/app/models/twilio_redirection.rb
+++ b/app/models/twilio_redirection.rb
@@ -1,0 +1,38 @@
+class TwilioRedirection
+  def self.for(twilio_number)
+    Location.for(twilio_number) || CallCentre.for(twilio_number)
+  end
+
+  class Location
+    def self.for(twilio_number)
+      location = ::Location.current.find_by(twilio_number: twilio_number)
+      location ? new(location.booking_location || location) : nil
+    end
+
+    def initialize(location)
+      @location = location
+    end
+
+    def phone
+      return ::Location::TP_CALL_CENTRE_NUMBER if @location.hidden?
+
+      @location.phone
+    end
+
+    def phone_options
+      return {} if @location.extension.blank?
+      { sendDigits: @location.extension }
+    end
+  end
+
+  class CallCentre < SimpleDelegator
+    def self.for(twilio_number)
+      call_centre = ::CallCentre.find_by(twilio_number: twilio_number)
+      call_centre ? CallCentre.new(call_centre) : nil
+    end
+
+    def phone_options
+      {}
+    end
+  end
+end

--- a/app/validators/uk_phone_number_validator.rb
+++ b/app/validators/uk_phone_number_validator.rb
@@ -3,6 +3,7 @@ class UkPhoneNumberValidator < ActiveModel::EachValidator
 
   def validate_each(record, attribute, value)
     return if value.to_s =~ REGEXP
+
     record.errors.add(attribute, :invalid, options.dup.merge!(value: value))
   end
 end

--- a/app/validators/uk_phone_number_validator.rb
+++ b/app/validators/uk_phone_number_validator.rb
@@ -1,0 +1,8 @@
+class UkPhoneNumberValidator < ActiveModel::EachValidator
+  REGEXP = /\A\+44\d{9,10}\z/
+
+  def validate_each(record, attribute, value)
+    return if value.to_s =~ REGEXP
+    record.errors.add(attribute, :invalid, options.dup.merge!(value: value))
+  end
+end

--- a/app/views/twilios/show.xml.builder
+++ b/app/views/twilios/show.xml.builder
@@ -1,0 +1,6 @@
+xml.instruct!
+xml.Response do
+  xml.Dial do
+    xml.Number @twilio_redirection.phone, @twilio_redirection.phone_options
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
   resources :locators, only: :index
   resources :locations, only: :index
 
+  post 'twilio' => 'twilios#show'
+
   namespace :admin do
     resources :locations, only: [:index, :update, :show, :edit]
     resources :edited_locations, only: [:index]

--- a/db/migrate/20160405090141_add_active_record_lookups_to_replace_curie.rb
+++ b/db/migrate/20160405090141_add_active_record_lookups_to_replace_curie.rb
@@ -24,6 +24,7 @@ class AddActiveRecordLookupsToReplaceCurie < ActiveRecord::Migration
 
   def extract_uid(field)
     return nil if field.nil?
+
     field.match(/^\[[^:]*:(.*)\]$/)[1]
   end
 end

--- a/spec/factories/call_center.rb
+++ b/spec/factories/call_center.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :call_centre do
+    uid { SecureRandom.uuid }
+    sequence(:purpose) { |n| "Promotion #{n}" }
+    sequence(:phone) { |n| "+44100000#{1000 + n}" }
+    sequence(:twilio_number) { |n| "+44111111#{1000 + n}" }
+  end
+end

--- a/spec/features/twilio_number_lookup_spec.rb
+++ b/spec/features/twilio_number_lookup_spec.rb
@@ -1,0 +1,137 @@
+require 'rails_helper'
+
+RSpec.describe 'Twilio number lookup', type: :request do
+  context 'when location exists for the uid' do
+    it 'will forward to the location phones' do
+      given_a_location_exists
+      when_twilio_requests_a_forwarding_number
+      then_xml_containing_the_location_number_is_returned
+    end
+
+    it 'will include the locations extension is one exists' do
+      given_a_location_exists_that_requires_an_extension
+      when_twilio_requests_a_forwarding_number
+      then_xml_containing_the_location_number_and_extension_is_returned
+    end
+
+    it 'will forward to the booking location phone number' do
+      given_a_location_exists_with_a_booking_location
+      when_twilio_requests_a_forwarding_number
+      then_xml_containing_the_booking_location_number_is_returned
+    end
+
+    context 'when location is hidden' do
+      it 'will forward to the booking location phone number if it is active' do
+        given_a_hidden_location_exists_with_a_booking_location
+        when_twilio_requests_a_forwarding_number
+        then_xml_containing_the_booking_location_number_is_returned
+      end
+
+      it 'will forward to the TP call centre' do
+        given_a_hidden_location_exists
+        when_twilio_requests_a_forwarding_number
+        then_xml_containing_the_tp_call_centre_is_returned
+      end
+    end
+  end
+
+  context 'when call centre exists for the uid' do
+    it 'will forward to the location phones' do
+      given_a_call_centre_exists
+      when_twilio_requests_a_forwarding_number
+      then_xml_containing_the_call_centre_number_is_returned
+    end
+  end
+
+  context 'when no call centre number is passed in' do
+    it 'will forward to the location phones' do
+      when_twilio_requests_a_blank_forwarding_number
+      then_a_bad_request_status_is_returned
+    end
+  end
+
+  context 'when no call centre number is passed in' do
+    it 'will forward to the location phones' do
+      when_twilio_requests_a_unknown_forwarding_number
+      then_a_not_found_status_is_returned
+    end
+  end
+
+  def given_a_location_exists
+    @redirection = create(:location)
+  end
+
+  def given_a_location_exists_that_requires_an_extension
+    @redirection = create(:location, extension: '25')
+  end
+
+  def given_a_location_exists_with_a_booking_location
+    @booking_location = create(:location)
+    @redirection = create(:location, phone: nil, booking_location: @booking_location)
+  end
+
+  def given_a_hidden_location_exists_with_a_booking_location
+    @booking_location = create(:location)
+    @redirection = create(:location, phone: nil, booking_location: @booking_location, hidden: true)
+  end
+
+  def given_a_hidden_location_exists
+    @redirection = create(:location, hidden: true)
+  end
+
+  def given_a_call_centre_exists
+    @redirection = create(:call_centre)
+  end
+
+  def when_twilio_requests_a_forwarding_number
+    post twilio_path, To: @redirection.twilio_number, format: :xml
+  end
+
+  def when_twilio_requests_a_blank_forwarding_number
+    post twilio_path, To: '', format: :xml
+  end
+
+  def when_twilio_requests_a_unknown_forwarding_number
+    post twilio_path, To: '+1111111', format: :xml
+  end
+
+  def then_xml_containing_the_location_number_is_returned
+    expect(response.body).to eq(xml_for("<Number>#{@redirection.phone}</Number>"))
+  end
+
+  def then_xml_containing_the_location_number_and_extension_is_returned
+    xml_response = xml_for("<Number sendDigits=\"#{@redirection.extension}\">#{@redirection.phone}</Number>")
+    expect(response.body).to eq(xml_response)
+  end
+
+  def then_xml_containing_the_booking_location_number_is_returned
+    expect(response.body).to eq(xml_for("<Number>#{@booking_location.phone}</Number>"))
+  end
+
+  def then_xml_containing_the_tp_call_centre_is_returned
+    expect(response.body).to eq(xml_for("<Number>#{Location::TP_CALL_CENTRE_NUMBER}</Number>"))
+  end
+
+  def then_xml_containing_the_call_centre_number_is_returned
+    expect(response.body).to eq(xml_for("<Number>#{@redirection.phone}</Number>"))
+  end
+
+  def then_a_bad_request_status_is_returned
+    expect(response.code).to eq('400')
+  end
+
+  def then_a_not_found_status_is_returned
+    expect(response.code).to eq('404')
+  end
+
+  def xml_for(number)
+    <<~XML_END
+      <?xml version="1.0" encoding="UTF-8"?>
+      <Response>
+        <Dial>
+          #{number}
+        </Dial>
+      </Response>
+    XML_END
+  end
+end


### PR DESCRIPTION
[DO NOT MERGE] The first two commits needs to be merged and deployed separately to ensure
the system does not crash

Add Twilio phone number to location model and call center model to hold
promotional phone numbers.

Add Twilio XML endpoint.

This is a stage 1 to turning off the switchboard application.  Additional work still required:

* putting the Twilio number in /location.json 
* remove the switchboard dependancy from the pensionwise application
* testing the twilio redirections using the new endpoint
* other integration items.