### PR TITLE
Remove bundler/ruby version from Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -350,9 +350,3 @@ DEPENDENCIES
   vcr
   web-console (~> 2.0)
   webmock
-
-RUBY VERSION
-   ruby 2.3.0p0
-
-BUNDLED WITH
-   1.12.3


### PR DESCRIPTION
This breaks the ruby install with the latest bundler
version 1.12.5 in the new heroku-ruby-buildpack