### PR TITLE
Allow post requests to /twilio without auth token

### DIFF
--- a/app/controllers/twilios_controller.rb
+++ b/app/controllers/twilios_controller.rb
@@ -1,4 +1,6 @@
 class TwiliosController < ApplicationController
+  protect_from_forgery with: :null_session
+
   def show
     if params[:To].blank?
       head :bad_request


### PR DESCRIPTION
Without this set it raised an ActionController::InvalidAuthenticityToken
error. This should be removed if/when we move
to using get requests.