### PR TITLE
Remove spec profile reporting

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,11 +69,6 @@ RSpec.configure do |config|
     config.default_formatter = 'doc'
   end
 
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 3
-
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.


### PR DESCRIPTION
Nobody acts on this information so it's just noise in the spec output.