### PR TITLE
Update README in respect of Ruby and Signon

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Manage [Pension Wise] locations.
 * [Bundler]
 * [Git]
 * [PostgreSQL]
-* [Ruby 2.3.0][Ruby]
-* [Signon] - not yet implemented
+* [Ruby 2.3.1][Ruby]
+* [Signon]
 
 
 ## Installation


### PR DESCRIPTION
Signon *is* implemented, plus we bumped Ruby to 2.3.1 a while back.