### PR TITLE
Serialize online booking twilio number

### DIFF
--- a/app/views/api/v1/booking_locations/_booking_location.json.jbuilder
+++ b/app/views/api/v1/booking_locations/_booking_location.json.jbuilder
@@ -1,6 +1,7 @@
 json.uid location.uid
 json.name location.title
 json.address location.address_line
+json.online_booking_twilio_number location.online_booking_twilio_number
 json.locations location.locations do |child|
   json.partial! 'booking_location', location: child
 end

--- a/db/migrate/20160707140820_add_online_booking_twilio_number_to_location.rb
+++ b/db/migrate/20160707140820_add_online_booking_twilio_number_to_location.rb
@@ -1,0 +1,5 @@
+class AddOnlineBookingTwilioNumberToLocation < ActiveRecord::Migration
+  def change
+    add_column :locations, :online_booking_twilio_number, :string, default: '', null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160610135053) do
+ActiveRecord::Schema.define(version: 20160707140820) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,19 +55,20 @@ ActiveRecord::Schema.define(version: 20160610135053) do
     t.string   "organisation"
     t.string   "title"
     t.string   "phone"
-    t.string   "hours",                limit: 500
-    t.string   "state",                            default: "pending"
+    t.string   "hours",                        limit: 500
+    t.string   "state",                                    default: "pending"
     t.datetime "closed_at"
     t.integer  "version"
     t.jsonb    "raw"
-    t.datetime "created_at",                                           null: false
-    t.datetime "updated_at",                                           null: false
-    t.boolean  "hidden",                           default: false
+    t.datetime "created_at",                                                   null: false
+    t.datetime "updated_at",                                                   null: false
+    t.boolean  "hidden",                                   default: false
     t.integer  "address_id"
     t.string   "booking_location_uid"
     t.integer  "editor_id"
     t.string   "twilio_number"
     t.string   "extension"
+    t.string   "online_booking_twilio_number",             default: "",        null: false
   end
 
   add_index "locations", ["booking_location_uid"], name: "index_locations_on_booking_location_uid", using: :btree

--- a/spec/factories/location.rb
+++ b/spec/factories/location.rb
@@ -30,6 +30,8 @@ FactoryGirl.define do
     end
 
     factory :booking_location do
+      online_booking_twilio_number '+441442800110'
+
       after(:create) do |parent|
         create(:guider, location: parent)
 

--- a/spec/views/api/v1/booking_locations/show.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/booking_locations/show.json.jbuilder_spec.rb
@@ -17,13 +17,15 @@ RSpec.describe 'api/v1/booking_locations/show.json.jbuilder' do
     expect(subject).to include(
       'uid' => booking_location.uid,
       'name' => booking_location.title,
-      'address' => booking_location.address_line
+      'address' => booking_location.address_line,
+      'online_booking_twilio_number' => booking_location.online_booking_twilio_number
     )
 
     expect(subject['locations'].first).to eq(
       'uid' => booking_location.locations.first.uid,
       'name' => booking_location.locations.first.title,
       'address' => booking_location.locations.first.address_line,
+      'online_booking_twilio_number' => '',
       'locations' => []
     )
 


### PR DESCRIPTION
Adds the online booking specific twilio number to serialized locations
for the booking locations API. This is so we can track any online
booking specific interactions from customers.