### PR TITLE
Only return active and current locations

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -47,7 +47,11 @@ class Location < ActiveRecord::Base
 
   class << self
     def booking_location_for(uid)
-      location = includes(:locations, :guiders).find_by(uid: uid)
+      location = includes(:locations, :guiders)
+                 .current
+                 .active
+                 .find_by(uid: uid)
+
       location&.booking_location || location
     end
 

--- a/app/views/api/v1/booking_locations/_booking_location.json.jbuilder
+++ b/app/views/api/v1/booking_locations/_booking_location.json.jbuilder
@@ -2,6 +2,6 @@ json.uid location.uid
 json.name location.title
 json.address location.address_line
 json.online_booking_twilio_number location.online_booking_twilio_number
-json.locations location.locations do |child|
+json.locations location.locations.active.current do |child|
   json.partial! 'booking_location', location: child
 end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -61,6 +61,30 @@ RSpec.describe Location do
         expect(subject).to eq(booking_location)
       end
     end
+
+    context 'with multiple locations of differing version' do
+      let(:uid) { booking_location.uid }
+
+      before do
+        booking_location.update_attribute(:state, 'old')
+      end
+
+      it 'returns only the current version' do
+        expect(subject).to be_nil
+      end
+    end
+
+    context 'with inactive locations' do
+      let(:uid) { booking_location.uid }
+
+      before do
+        booking_location.update_attribute(:hidden, true)
+      end
+
+      it 'returns only active versions' do
+        expect(subject).to be_nil
+      end
+    end
   end
 
   describe '.externally_visible' do


### PR DESCRIPTION
We were not respecting these flags so the response was
non-deterministic, given it included old and outdated versions of
locations.