### PR TITLE
Enforce blank phone/hours when booking location exists

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -28,12 +28,16 @@ class Location < ActiveRecord::Base
   validates :organisation, presence: true, inclusion: ORGANISATIONS
   validates :title, presence: true
   validates :address, presence: true
-  validates :booking_location, presence: { if: ->(l) { l.phone.nil? } }
+  validates :booking_location,
+            presence: { if: ->(l) { l.phone.blank? } }
   validates :version, presence: true
   validates :state, presence: true, inclusion: %w(old current)
   validates :phone,
             presence: { if: ->(l) { l.booking_location.blank? } },
+            absence: { if: ->(l) { l.booking_location.present? } },
             uk_phone_number: { if: :current_with_phone_number? }
+  validates :hours,
+            absence: { if: ->(l) { l.booking_location.present? } }
   validates :twilio_number,
             uniqueness: { conditions: -> { current } },
             uk_phone_number: true,
@@ -93,7 +97,7 @@ class Location < ActiveRecord::Base
   end
 
   def current_with_phone_number?
-    current? && phone.present?
+    current? && booking_location.nil? && phone.present?
   end
 
   def current_with_twilio_number?

--- a/app/views/admin/locations/_form.html.erb
+++ b/app/views/admin/locations/_form.html.erb
@@ -70,12 +70,6 @@
   </div>
 <% end %>
 
-<div class="form-group <%= 'form-group--error' if f.object.errors[:hours].any? %>" id="hours">
-  <%= f.label :hours, 'Booking hours' %>
-  <%= render 'error', error_messages: location.errors[:hours] %>
-  <%= f.text_area :hours, class: 'input-md-3 form-control t-booking-hours' %>
-</div>
-
 <div class="form-group <%= 'form-group--error' if f.object.errors[:booking_location].any? %>" id="booking_location">
   <%= f.label :booking_location_uid, 'Booking location:' %>
   <%= render 'error', error_messages: location.errors[:booking_location] %>
@@ -88,6 +82,12 @@
         class: 'input-md-3 form-control t-booking-location'
       )
   %>
+</div>
+
+<div class="form-group <%= 'form-group--error' if f.object.errors[:hours].any? %>" id="hours">
+  <%= f.label :hours, 'Booking hours' %>
+  <%= render 'error', error_messages: location.errors[:hours] %>
+  <%= f.text_area :hours, class: 'input-md-3 form-control t-booking-hours' %>
 </div>
 
 <div class="form-group <%= 'form-group--error' if f.object.errors[:phone].any? %>" id="phone">
@@ -105,14 +105,14 @@
 <% end %>
 
 <div class="form-group t-visibility <%= 'form-group--error' if f.object.errors[:hidden].any? %>" id="hidden">
-  <%= f.label :hidden, 'Visibility', class: 'block' %><br/>
+  <%= f.label :hidden, 'Make location visible?', class: 'block' %><br/>
   <%= render 'error', error_messages: location.errors[:hidden] %>
   <%= hidden_field_tag :display_hidden, params[:display_hidden] %>
   <%= hidden_field_tag :display_active, params[:display_active] %>
   <%= f.radio_button :hidden, false, class: 'l-location-status__checkbox t-hidden-false', id: "location_hidden_false_#{location.id}" %>
-  <%= f.label "hidden_false_#{location.id}", 'Active', class: 'l-location-status__label' %>
+  <%= f.label "hidden_false_#{location.id}", 'Yes', class: 'l-location-status__label' %>
   <%= f.radio_button :hidden, true, class: 'l-location-status__checkbox t-hidden-true', id: "location_hidden_true_#{location.id}" %>
-  <%= f.label "hidden_true_#{location.id}", 'Hidden', class: 'l-location-status__label' %>
+  <%= f.label "hidden_true_#{location.id}", 'No', class: 'l-location-status__label' %>
 </div>
 
 <div class="form-group">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,13 +27,16 @@ en:
           attributes:
             phone:
               invalid: Please use the format +44XXXXXXXXXX
+              present: Leave blank when booking location exists
             title:
               blank: Please enter the title
             twilio_number:
               invalid: Please use the format +44XXXXXXXXXX
               taken: That number is already in use
             hidden:
-              inclusion: Must be hidden until a twilio number is set
+              inclusion: Can't be visible - additional admin needed
+            hours:
+              present: Leave blank when booking location exists
         address:
           attributes:
             postcode:

--- a/db/migrate/20160809103637_remove_phone_when_booking_location.rb
+++ b/db/migrate/20160809103637_remove_phone_when_booking_location.rb
@@ -1,0 +1,15 @@
+class RemovePhoneWhenBookingLocation < ActiveRecord::Migration
+  def change
+    execute %(
+      UPDATE locations
+      SET phone = ''
+      WHERE (phone != '' OR phone IS NOT NULL) and booking_location_uid IS NOT NULL
+    )
+
+    execute %(
+      UPDATE locations
+      SET hours = ''
+      WHERE (hours != '' OR hours IS NOT NULL) and booking_location_uid IS NOT NULL
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160728144324) do
+ActiveRecord::Schema.define(version: 20160809103637) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/features/admin_location.feature
+++ b/features/admin_location.feature
@@ -15,10 +15,10 @@ Feature: Admin - Location Directory
     Then the "Apples" location has a new version where "<Field>" has been set to "<Value>"
 
     Examples:
-      | method | Field            | Value                  |
-      | set    | location_title   | Super Location         |
-      | set    | booking_hours    | Mon to Fri 6am to 1pm  |
-      | choose | visibility       | Hidden                 |
+      | method | Field                 | Value                  |
+      | set    | location_title        | Super Location         |
+      | set    | booking_hours         | Mon to Fri 6am to 1pm  |
+      | choose | make_location_visible | No                     |
 
   Scenario: Editing a locations booking location creates a new version with the updated values
     Given two locations exist called "Apples" and "Bamboo"

--- a/features/pages/admin_edit_location_page.rb
+++ b/features/pages/admin_edit_location_page.rb
@@ -3,7 +3,7 @@ class AdminEditLocationPage < SitePrism::Page
 
   element :location_title, '.t-location-title'
   element :booking_hours, '.t-booking-hours'
-  element :visibility, '.t-visibility'
+  element :make_location_visible, '.t-visibility'
   element :booking_location, '.t-booking-location'
 
   element :address_line_1, '.t-address-line-1'

--- a/features/step_definitions/admin/location_directory_steps.rb
+++ b/features/step_definitions/admin/location_directory_steps.rb
@@ -36,7 +36,7 @@ end
 
 Given(/^two locations exist called "([^"]*)" and "([^"]*)"$/) do |title1, title2|
   create(:user, :project_manager, :nicab)
-  create(:location, :nicab, title: title1)
+  create(:location, :nicab, title: title1, booking_location: create(:location))
   create(:location, :nicab, title: title2)
 end
 

--- a/features/step_definitions/admin/location_steps.rb
+++ b/features/step_definitions/admin/location_steps.rb
@@ -43,7 +43,9 @@ Then(/^the "([^"]*)" location has a new version where "([^"]*)" has been set to 
   previous_location, current_location = *LocationTestHelper.get_all_location_versions(title: title)
 
   edited_fields = EditedLocationField.all(current_location, previous_location)
-  expect(edited_fields).to equal_edits([{ field: LocationTestHelper.field_name(field), new_value: value }])
+  expect(edited_fields).to equal_edits(
+    [{ field: LocationTestHelper.field_name(field), new_value: LocationTestHelper.field_value(field, value) }]
+  )
 end
 
 Then(/^the "([^"]*)" location address has been updated to have "([^"]*)" set to "([^"]*)"$/) do |title, _field, value|
@@ -59,7 +61,11 @@ Then(/^I should see an error message for "([^"]*)"$/) do |field|
 end
 
 module LocationTestHelper
-  FIELD_NAME_MAP = { 'location_title' => 'title', 'booking_hours' => 'hours' }.freeze
+  FIELD_NAME_MAP = {
+    'location_title' => 'title',
+    'booking_hours' => 'hours',
+    'make_location_visible' => 'visibility'
+  }.freeze
 
   module_function
 
@@ -70,5 +76,10 @@ module LocationTestHelper
 
   def field_name(field)
     FIELD_NAME_MAP[field] || field
+  end
+
+  def field_value(field, value)
+    return value unless field == 'make_location_visible'
+    value == 'No' ? 'Hidden' : 'Active'
   end
 end

--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -1,8 +1,7 @@
 FactoryGirl.define do
   factory :address do
     uid { SecureRandom.uuid }
-    address 'Flat 10'
-    address_line_1 'Test flat 3'
+    sequence(:address_line_1) { |n| "Test flat #{n}" }
     address_line_2 'Testing center'
     address_line_3 'Test Avenue'
     town 'Test Vile'

--- a/spec/factories/location.rb
+++ b/spec/factories/location.rb
@@ -13,6 +13,13 @@ FactoryGirl.define do
     booking_location nil
     editor { build(:user) }
 
+    before(:create) do |location|
+      if location.booking_location.present?
+        location.hours = nil
+        location.phone = nil
+      end
+    end
+
     trait :cas do
       organisation 'cas'
     end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Address do
       address = build(:address)
       expect(address.to_a).to eq(
         [
-          'Test flat 3',
+          address.address_line_1,
           'Testing center',
           'Test Avenue',
           'Test Vile',

--- a/spec/views/locations/index.json.jbuilder_spec.rb
+++ b/spec/views/locations/index.json.jbuilder_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'locations/index' do
           },
           'properties' => {
             'title' => 'Test location',
-            'address' => "Test flat 3\nTesting center\nTest Avenue\nTest Vile\nTesty\nUB9 4LH",
+            'address' => "#{location.address.address_line_1}\nTesting center\nTest Avenue\nTest Vile\nTesty\nUB9 4LH",
             'booking_location_id' => '',
             'phone' => location.phone,
             'hours' => 'MON-FRI 9am-5pm',


### PR DESCRIPTION
When a booking location exists these fields should
be delegated to the booking location. this is required
to ensure that changes to these values on the 
booking location are propagated through.