### PR TITLE
Allow phone numbers be edited by admin

### DIFF
--- a/app/policies/location_policy.rb
+++ b/app/policies/location_policy.rb
@@ -16,7 +16,7 @@ class LocationPolicy < ApplicationPolicy
   end
 
   def phone?
-    record.version.nil? || (record.version == 1 && record.new_record?)
+    record.version.nil? || (record.version == 1 && record.new_record?) || admin?
   end
 
   def edit?
@@ -48,15 +48,19 @@ class LocationPolicy < ApplicationPolicy
       address: [:address_line_1, :address_line_2, :address_line_3, :town, :county, :postcode]
     ]
 
-    base_params << :phone if record == Location
-    base_params << :organisation << :twilio_number if admin?
+    base_params += [:phone] if creating_new_record? || admin?
+    base_params += [:organisation, :twilio_number] if admin?
 
     base_params
   end
 
   private
 
+  def creating_new_record?
+    record == Location
+  end
+
   def admin_or_organisations_project_manager?
-    user.pensionwise_admin? || (user.project_manager? && user.organisation_slug == record.organisation)
+    admin? || (user.project_manager? && user.organisation_slug == record.organisation)
   end
 end

--- a/app/views/admin/locations/_form.html.erb
+++ b/app/views/admin/locations/_form.html.erb
@@ -71,7 +71,7 @@
 <% end %>
 
 <div class="form-group <%= 'form-group--error' if f.object.errors[:booking_location].any? %>" id="booking_location">
-  <%= f.label :booking_location_uid, 'Booking location:' %>
+  <%= f.label :booking_location_uid, 'Booking location' %>
   <%= render 'error', error_messages: location.errors[:booking_location] %>
   <%= f.collection_select(
         :booking_location_uid,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,7 @@ en:
             phone:
               invalid: Please use the format +44XXXXXXXXXX
               present: Leave blank when booking location exists
+              twilio_must_be_changed: Twilio number must also be changed
             title:
               blank: Please enter the title
             twilio_number:

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -101,4 +101,56 @@ RSpec.describe Location do
       expect(locations).to match_array([active_location])
     end
   end
+
+  describe 'editing the phone number' do
+    let(:version_3) do
+      build(:location, uid: '12345', version: 3, phone: '+44123456111', twilio_number: '+44987654321', state: 'old')
+        .tap { |l| l.save!(validate: false) }
+    end
+    let(:version_4) do
+      version_3
+      build(:location, uid: '12345', version: 4, phone: version_4_phone, twilio_number: version_4_twilio, state: 'old')
+        .tap { |l| l.save!(validate: false) }
+    end
+    let(:version_5) do
+      version_4
+      build(:location, uid: '12345', version: 5, phone: version_5_phone, twilio_number: version_5_twilio)
+    end
+
+    it 'can create a new record with a phone number' do
+      location = build(:location, twilio_number: nil, hidden: true)
+      expect(location).to be_valid
+    end
+
+    context 'phone number has changed' do
+      let(:version_4_phone) { '+44123456789' }
+      let(:version_5_phone) { '+44123456222' }
+
+      context 'twilio number has changed' do
+        let(:version_4_twilio) { '+44987654321' }
+        let(:version_5_twilio) { '+44987654222' }
+
+        it 'existing records are valid' do
+          expect(version_4).to be_valid
+        end
+
+        it 'edits are valid' do
+          expect(version_5).to be_valid
+        end
+      end
+
+      context 'twilio number has not changed' do
+        let(:version_4_twilio) { '+44987654321' }
+        let(:version_5_twilio) { '+44987654321' }
+
+        it 'existing records are valid' do
+          expect(version_4).to be_valid
+        end
+
+        it 'edits are invalid' do
+          expect(version_5).not_to be_valid
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Requires a corresponding Twilio number change
to occur.

This is to allow the new request from NICAB to change the external phone number of a booking location.