### PR TITLE
Ensure old twilio number is redirected correctly

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -97,6 +97,10 @@ class Location < ActiveRecord::Base # rubocop: disable Metrics/ClassLength
     booking_location || self
   end
 
+  def current_version
+    self.class.current.find_by(uid: uid)
+  end
+
   def matches_params?(params)
     EDIT_FIELDS.all? do |field_name|
       !params.key?(field_name) || params[field_name].to_s == self[field_name].to_s

--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :address do
     uid { SecureRandom.uuid }
     sequence(:address_line_1) { |n| "Test flat #{n}" }
-    address_line_2 'Testing center'
+    address_line_2 'Testing centre'
     address_line_3 'Test Avenue'
     town 'Test Vile'
     county 'Testy'

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Address do
       expect(address.to_a).to eq(
         [
           address.address_line_1,
-          'Testing center',
+          'Testing centre',
           'Test Avenue',
           'Test Vile',
           'Testy',

--- a/spec/models/twilio_redirect_spec.rb
+++ b/spec/models/twilio_redirect_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe TwilioRedirection do
+  describe '.for' do
+    let(:twilio_number) { '+44123456789' }
+    let!(:location) { create(:location, twilio_number: twilio_number, hidden: hidden) }
+
+    context 'when the twilio number exists on a current location' do
+      context 'and the location is active' do
+        let(:hidden) { false }
+
+        it 'redirects to the locations phone number' do
+          expect(described_class.for(twilio_number).phone).to eq(location.phone)
+        end
+      end
+
+      context 'and the location is hidden' do
+        let(:hidden) { true }
+
+        it 'redirects to the call centre' do
+          expect(described_class.for(twilio_number).phone).to eq(::Location::TP_CALL_CENTRE_NUMBER)
+        end
+      end
+    end
+
+    context 'when the twilio number exists on a old location' do
+      let(:user) { create(:user) }
+      let(:params) { { 'twilio_number' => '+44987654321', 'phone' => '+44111222333' } }
+      let!(:current_location) { CreateOrUpdateLocation.new(location: location, user: user).update(params) }
+
+      context 'and the current version of the location is active' do
+        let(:hidden) { false }
+
+        it "redirects to the current location's phone number" do
+          expect(described_class.for(twilio_number).phone).to eq(current_location.phone)
+        end
+      end
+
+      context 'and the current version of the location is hidden' do
+        let(:hidden) { true }
+
+        it 'redirects to the call centre' do
+          expect(described_class.for(twilio_number).phone).to eq(::Location::TP_CALL_CENTRE_NUMBER)
+        end
+      end
+    end
+  end
+end

--- a/spec/views/locations/index.json.jbuilder_spec.rb
+++ b/spec/views/locations/index.json.jbuilder_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'locations/index' do
           },
           'properties' => {
             'title' => 'Test location',
-            'address' => "#{location.address.address_line_1}\nTesting center\nTest Avenue\nTest Vile\nTesty\nUB9 4LH",
+            'address' => "#{location.address.address_line_1}\nTesting centre\nTest Avenue\nTest Vile\nTesty\nUB9 4LH",
             'booking_location_id' => '',
             'phone' => location.phone,
             'hours' => 'MON-FRI 9am-5pm',


### PR DESCRIPTION
When a twill number is updated, the old number
should continue to work and redirect to the
current phone number for the location.