### PR TITLE
Increase grace period to three days (or more)

### DIFF
--- a/app/models/slot.rb
+++ b/app/models/slot.rb
@@ -1,4 +1,12 @@
 Slot = Struct.new(:date, :start, :end) do
+  GRACE_PERIODS = {
+    3 => :monday,
+    4 => :tuesday,
+    5 => :wednesday,
+    6 => :thursday,
+    0 => :thursday
+  }.freeze
+
   def self.all
     slot_dates.map do |date|
       [
@@ -9,11 +17,20 @@ Slot = Struct.new(:date, :start, :end) do
   end
 
   def self.slot_dates
-    grace_period = Time.zone.today + 2.days
     booking_window_end = 6.weeks.from_now
 
     (grace_period..booking_window_end).reject do |date|
       date.saturday? || date.sunday?
+    end
+  end
+
+  def self.grace_period
+    today = Time.zone.today
+
+    if today.monday? || today.tuesday?
+      today.advance(days: 3)
+    else
+      today.next_week(GRACE_PERIODS[today.wday])
     end
   end
 end

--- a/spec/models/slot_spec.rb
+++ b/spec/models/slot_spec.rb
@@ -2,34 +2,50 @@ require 'rails_helper'
 
 RSpec.describe Slot do
   subject do
-    travel_to '2016-06-07 10:00:00' do
-      Slot.all
+    travel_to(date) { Slot.all }
+  end
+
+  context 'on Sunday' do
+    let(:date) { '2016-06-05 10:00:00' }
+
+    it 'the first slot is the following Thursday' do
+      expect(subject.first).to have_attributes(date: '2016-06-09')
     end
   end
 
-  it 'returns slots for morning and afternoon' do
-    expect(subject.first).to have_attributes(
-      date: '2016-06-09',
-      start: '0900',
-      end: '1300'
-    )
+  context 'on Friday' do
+    let(:date) { '2016-06-10 10:00:00' }
 
-    expect(subject.second).to have_attributes(
-      date: '2016-06-09',
-      start: '1300',
-      end: '1700'
-    )
+    it 'the first slot is the following Wednesday' do
+      expect(subject.first).to have_attributes(date: '2016-06-15')
+    end
   end
 
-  it 'returns slots two days from now' do
-    expect(subject.first).to have_attributes(date: '2016-06-09')
-  end
+  context 'on Monday' do
+    let(:date) { '2016-06-06 10:00:00' }
 
-  it 'ignores weekends' do
-    expect(
-      subject
+    it 'returns slots for morning and afternoon' do
+      expect(subject.first).to have_attributes(
+        start: '0900',
+        end: '1300'
+      )
+
+      expect(subject.second).to have_attributes(
+        start: '1300',
+        end: '1700'
+      )
+    end
+
+    it 'the first slot is the same Thursday' do
+      expect(subject.first).to have_attributes(date: '2016-06-09')
+    end
+
+    it 'ignores weekends' do
+      expect(
+        subject
         .map { |slot| Date.parse(slot.date) }
         .none? { |d| d.saturday? || d.sunday? }
-    ).to be_truthy
+      ).to be_truthy
+    end
   end
 end

--- a/spec/views/api/v1/booking_locations/show.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/booking_locations/show.json.jbuilder_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'api/v1/booking_locations/show.json.jbuilder' do
     )
 
     expect(subject['slots'].first).to eq(
-      'date' => '2016-06-07',
+      'date' => '2016-06-09',
       'start' => '0900',
       'end' => '1300'
     )


### PR DESCRIPTION
In keeping with some location's requirements around the earliest
available slots to book, the grace period for the earliest booking is
now mapped as follows:

```
Monday    | same Thursday
Tuesday   | same Friday
Wednesday | next Monday
Thursday  | next Tuesday
Friday    | next Wednesday
Saturday  | next Thursday
Sunday    | next Thursday
```