### PR TITLE
Additions for online bookings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ group :test do
   gem 'database_cleaner'
   gem 'factory_girl_rails'
   gem 'poltergeist'
+  gem 'phantomjs', require: 'phantomjs/poltergeist'
   gem 'site_prism'
   gem 'vcr'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,7 +52,7 @@ GEM
       multi_json (~> 1.0)
     builder (3.2.2)
     byebug (8.2.2)
-    capybara (2.6.2)
+    capybara (2.10.1)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -153,9 +153,8 @@ GEM
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     newrelic_rpm (3.12.0.288)
-    nokogiri (1.6.8)
+    nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
-      pkg-config (~> 1.1.7)
     oauth2 (1.2.0)
       faraday (>= 0.8, < 0.10)
       jwt (~> 1.0)
@@ -174,12 +173,11 @@ GEM
     parser (2.3.1.2)
       ast (~> 2.2)
     pg (0.18.4)
-    pkg-config (1.1.7)
+    phantomjs (2.1.1.0)
     plek (1.12.0)
-    poltergeist (1.6.0)
+    poltergeist (1.11.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
-      multi_json (~> 1.0)
       websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
     pry (0.10.3)
@@ -306,7 +304,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    websocket-driver (0.6.2)
+    websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
     xpath (2.0.0)
@@ -333,6 +331,7 @@ DEPENDENCIES
   jquery-rails
   newrelic_rpm
   pg (~> 0.15)
+  phantomjs
   plek
   poltergeist
   pry-byebug
@@ -357,4 +356,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.5
+   1.13.1

--- a/app/controllers/admin/guiders_controller.rb
+++ b/app/controllers/admin/guiders_controller.rb
@@ -1,0 +1,30 @@
+module Admin
+  class GuidersController < Admin::BaseController
+    before_action :set_authorised_location, :set_guider
+
+    def index
+      @guiders = @location.guiders
+    end
+
+    def create
+      @location.guiders.create!(guider_params)
+
+      redirect_to admin_location_guiders_path(@location.uid)
+    end
+
+    private
+
+    def guider_params
+      params.require(:guider).permit(:name, :email)
+    end
+
+    def set_guider
+      @guider = Guider.new(location: @location)
+    end
+
+    def set_authorised_location
+      @location ||= Location.current.find_by!(uid: params[:location_id])
+      authorize @location
+    end
+  end
+end

--- a/app/controllers/admin/locations_controller.rb
+++ b/app/controllers/admin/locations_controller.rb
@@ -1,6 +1,6 @@
 module Admin
   class LocationsController < Admin::BaseController
-    before_action :set_authorised_location, only: [:update, :show, :edit]
+    before_action :set_authorised_location, only: [:update, :show, :edit, :online_booking]
 
     def index
       authorize Location
@@ -45,6 +45,9 @@ module Admin
       else
         redirect_to admin_location_path(@location.uid), notice: "Successfully updated #{@location.title}"
       end
+    end
+
+    def online_booking
     end
 
     private

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -40,6 +40,10 @@ class Location < ActiveRecord::Base # rubocop: disable Metrics/ClassLength
             uniqueness: { conditions: -> { current } },
             uk_phone_number: true,
             if: :current_with_twilio_number?
+  validates :online_booking_twilio_number,
+            uk_phone_number: true,
+            allow_blank: true,
+            unless: :booking_location_uid?
   validates :guiders, length: { is: 0 }, if: :booking_location_uid?
   validates :hidden, inclusion: { in: [true], if: ->(l) { l.twilio_number.blank? } }
 

--- a/app/policies/location_policy.rb
+++ b/app/policies/location_policy.rb
@@ -39,6 +39,10 @@ class LocationPolicy < ApplicationPolicy
     admin_or_organisations_project_manager?
   end
 
+  def online_booking?
+    admin?
+  end
+
   def permitted_attributes
     base_params = [
       :booking_location_uid,

--- a/app/policies/location_policy.rb
+++ b/app/policies/location_policy.rb
@@ -49,7 +49,7 @@ class LocationPolicy < ApplicationPolicy
     ]
 
     base_params += [:phone] if creating_new_record? || admin?
-    base_params += [:organisation, :twilio_number] if admin?
+    base_params += [:organisation, :twilio_number, :online_booking_twilio_number] if admin?
 
     base_params
   end

--- a/app/views/admin/guiders/index.html.erb
+++ b/app/views/admin/guiders/index.html.erb
@@ -1,0 +1,38 @@
+<div class="row">
+  <div class="col-md-12">
+    <h1 class="inline-block">Guiders</h1>
+  </div>
+</div>
+<div class="row">
+  <div class="col-md-3 well">
+    <%= form_for @guider, url: admin_location_guiders_path(@location.uid) do |f| %>
+      <div class="form-group">
+        <%= f.label :name %>
+        <%= f.text_field :name, class: 'form-control t-name', placeholder: 'Jane Doe' %>
+      </div>
+      <div class="form-group">
+        <%= f.label :email %>
+        <%= f.email_field :email, class: 'form-control t-email', placeholder: 'jane.doe@example.com' %>
+      </div>
+      <%= f.button 'Add Guider', class: 'btn btn-default t-add' %>
+    <% end %>
+  </div>
+  <div class="col-md-9">
+    <table class="table table-bordered">
+      <thead>
+        <tr class="table-header">
+          <th>Name</th>
+          <th>Email</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @location.guiders.each do |guider| %>
+          <tr class="t-guider">
+            <td class="t-guider-name"><%= guider.name %></td>
+            <td class="t-guider-email"><%= guider.email %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/admin/locations/_form.html.erb
+++ b/app/views/admin/locations/_form.html.erb
@@ -102,6 +102,12 @@
     <%= render 'error', error_messages: location.errors[:twilio_number] %>
     <%= f.text_field :twilio_number, class: 'input-md-3 form-control t-twilio-number' %>
   </div>
+
+  <div class="form-group <%= 'form-group--error' if f.object.errors[:online_booking_twilio_number].any? %>" id="online-booking-twilio-number">
+    <%= f.label :online_booking_twilio_number, 'Online booking twilio number' %>
+    <%= render 'error', error_messages: location.errors[:online_booking_twilio_number] %>
+    <%= f.text_field :online_booking_twilio_number, class: 'input-md-3 form-control t-online-booking-twilio-number' %>
+  </div>
 <% end %>
 
 <div class="form-group t-visibility <%= 'form-group--error' if f.object.errors[:hidden].any? %>" id="hidden">

--- a/app/views/admin/locations/online_booking.html.erb
+++ b/app/views/admin/locations/online_booking.html.erb
@@ -1,0 +1,6 @@
+<pre>
+  <%= @location.uid %>
+  <% @location.locations.active.current.each do |location| %>
+    <%= location.uid %>
+  <% end %>
+</pre>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,10 @@ Rails.application.routes.draw do
   get 'twilio' => 'twilios#show'
 
   namespace :admin do
-    resources :locations, except: :destroy
+    resources :locations, except: :destroy do
+      resources :guiders, only: %i(index create)
+    end
+
     resources :edited_locations, only: [:index]
     root 'locations#index'
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :locations, except: :destroy do
+      get 'online_booking', on: :member
+
       resources :guiders, only: %i(index create)
     end
 

--- a/db/migrate/20161012092907_change_locations_online_booking_twilio_number_null.rb
+++ b/db/migrate/20161012092907_change_locations_online_booking_twilio_number_null.rb
@@ -1,0 +1,5 @@
+class ChangeLocationsOnlineBookingTwilioNumberNull < ActiveRecord::Migration
+  def change
+    change_column_null :locations, :online_booking_twilio_number, true, default: ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160809103637) do
+ActiveRecord::Schema.define(version: 20161012092907) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -68,7 +68,7 @@ ActiveRecord::Schema.define(version: 20160809103637) do
     t.integer  "editor_id"
     t.string   "twilio_number"
     t.string   "extension"
-    t.string   "online_booking_twilio_number",             default: "",        null: false
+    t.string   "online_booking_twilio_number",             default: ""
   end
 
   add_index "locations", ["booking_location_uid"], name: "index_locations_on_booking_location_uid", using: :btree

--- a/features/admin_location.feature
+++ b/features/admin_location.feature
@@ -64,3 +64,9 @@ Feature: Admin - Location Directory
     When I toggle the locations visiblity
     Then I get a permission denied error
     And the location is hidden
+
+  Scenario: Adding guiders for an online booking location
+    Given a location exists called "London"
+    When I visit the "London" location
+    And I add a guider
+    Then the guider is added

--- a/features/pages/admin_edit_location_page.rb
+++ b/features/pages/admin_edit_location_page.rb
@@ -17,6 +17,8 @@ class AdminEditLocationPage < SitePrism::Page
 
   element :save_button, '.t-save-button'
 
+  element :guiders, '.t-guiders'
+
   elements :errors, '.t-error-message'
 
   def error_messages

--- a/features/pages/admin_guider_page.rb
+++ b/features/pages/admin_guider_page.rb
@@ -1,0 +1,12 @@
+class AdminGuiderPage < SitePrism::Page
+  set_url '/admin/locations/{location_id}/guiders'
+
+  element :name, '.t-name'
+  element :email, '.t-email'
+  element :add, '.t-add'
+
+  sections :guiders, '.t-guider' do
+    element :name, '.t-guider-name'
+    element :email, '.t-guider-email'
+  end
+end

--- a/features/step_definitions/admin/location_steps.rb
+++ b/features/step_definitions/admin/location_steps.rb
@@ -26,9 +26,9 @@ Then(/^no location exists to view$/) do
 end
 
 When(/^I visit the "([^"]*)" location$/) do |location_title|
-  location = Location.find_by(title: location_title)
+  @location = Location.find_by(title: location_title)
   @page = AdminLocationPage.new
-  @page.load(uid: location.uid)
+  @page.load(uid: @location.uid)
 end
 
 When(/^I (.*) the locations "([^"]*)" field to "([^"]*)"$/) do |method, field, new_value|
@@ -58,6 +58,26 @@ end
 Then(/^I should see an error message for "([^"]*)"$/) do |field|
   edit_page = AdminEditLocationPage.new
   expect(edit_page.error_messages.first).to match(field)
+end
+
+When(/^I add a guider$/) do
+  AdminGuiderPage.new.tap do |guider_page|
+    guider_page.load(location_id: @location.uid)
+
+    guider_page.name.set 'Ben Lovell'
+    guider_page.email.set 'ben@example.com'
+    guider_page.add.click
+  end
+end
+
+Then(/^the guider is added$/) do
+  AdminGuiderPage.new.tap do |guider_page|
+    expect(guider_page).to be_displayed
+    expect(guider_page).to have_guiders(count: 1)
+
+    expect(guider_page.guiders.first.name.text).to eq('Ben Lovell')
+    expect(guider_page.guiders.first.email.text).to eq('ben@example.com')
+  end
 end
 
 module LocationTestHelper

--- a/spec/policies/location_policy_spec.rb
+++ b/spec/policies/location_policy_spec.rb
@@ -117,7 +117,8 @@ RSpec.describe LocationPolicy do
             },
             :phone,
             :organisation,
-            :twilio_number
+            :twilio_number,
+            :online_booking_twilio_number
           ]
         )
       end


### PR DESCRIPTION
_Note: This is very basic stuff just to speed up our process for enabling online booking locations. This will be incrementally improved as / when we have further locations to introduce._

## List locations heirarchically for online booking

Provides the location IDs heirarchically (including the booking location's
children) for us to copy-pasta or potentially curl for when enabling online
booking locations.

## Basic guiders admin screen

Adds a very simple guider administration screen. It isn't linked off the UI
anywhere as it is only used by us when adding guiders for online booking
enabled locations.

There is currently no validation or ability to edit / delete guiders. Maybe
I'll add that later should the need arise.

## Allow edits to `online_booking_twilio_number`

Grants administrators the ability to enter the online booking specific
twilio number on new or existing locations.

The number is now nullable, this is since nulls with get through when the
params are filtered (or when it isn't supplied) whereas previously this was
something that was only added through the console.