### PR TITLE
Add hours to /api/twilio_numbers endpoint

### DIFF
--- a/app/views/api/v1/twilio_numbers/index.json.jbuilder
+++ b/app/views/api/v1/twilio_numbers/index.json.jbuilder
@@ -10,6 +10,8 @@ json.twilio_numbers  do
 
       json.booking_location location.canonical_location.title
       json.booking_location_postcode location.canonical_location.address.postcode
+
+      json.hours location.canonical_location.hours
     end
   end
 end

--- a/spec/views/api/v1/twilio_numbers/index.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/twilio_numbers/index.json.jbuilder_spec.rb
@@ -12,22 +12,26 @@ RSpec.describe 'api/v1/twilio_numbers/index.json.jbuilder' do
   subject { JSON.parse(rendered)['twilio_numbers'] }
 
   it 'renders the particulars for a location without a booking location' do
-    expect(subject[booking_location.twilio_number]).to include(
+    expect(subject[booking_location.twilio_number]).to eq(
       'uid' => booking_location.uid,
       'location' => booking_location.title,
       'location_postcode' => booking_location.address.postcode,
       'booking_location' => booking_location.title,
-      'booking_location_postcode' => booking_location.address.postcode
+      'booking_location_postcode' => booking_location.address.postcode,
+      'delivery_partner' => booking_location.organisation,
+      'hours' => booking_location.hours
     )
   end
 
   it 'renders the particulars for a location with a booking location' do
-    expect(subject[location.twilio_number]).to include(
+    expect(subject[location.twilio_number]).to eq(
       'uid' => location.uid,
       'location' => location.title,
       'location_postcode' => location.address.postcode,
       'booking_location' => booking_location.title,
-      'booking_location_postcode' => booking_location.address.postcode
+      'booking_location_postcode' => booking_location.address.postcode,
+      'delivery_partner' => booking_location.organisation,
+      'hours' => booking_location.hours
     )
   end
 end


### PR DESCRIPTION
This is due to require for reporting to display
opening hours data beside call time information.

This will help to determine the number of unanswered
calls during opening hours for each location.