### PR TITLE
Add online booking number to /api/twilio endpoint

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -11,6 +11,7 @@ class Location < ActiveRecord::Base # rubocop: disable Metrics/ClassLength
     uid
     extension
     twilio_number
+    online_booking_twilio_number
   ).freeze
   TP_CALL_CENTRE_NUMBER = '+442037333495'
   ORGANISATIONS = %w(cas cita nicab).freeze
@@ -87,8 +88,8 @@ class Location < ActiveRecord::Base # rubocop: disable Metrics/ClassLength
         .each_with_object({}) do |location, hash|
           next if location.twilio_number.blank?
           hash[location.twilio_number] ||= location
+          hash[location.online_booking_twilio_number] ||= location if location.online_booking_twilio_number.present?
         end
-        .values
     end
   end
 

--- a/app/views/api/v1/twilio_numbers/index.json.jbuilder
+++ b/app/views/api/v1/twilio_numbers/index.json.jbuilder
@@ -1,6 +1,6 @@
 json.twilio_numbers  do
-  @locations.each do |location|
-    json.set!(location.twilio_number) do
+  @locations.each do |number, location|
+    json.set!(number) do
       json.uid location.uid
 
       json.delivery_partner location.organisation

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -10,7 +10,10 @@ RSpec.describe Location do
       let(:params) { { 'phone' => '+44999999999', 'twilio_number' => '+44999999111' } }
 
       it 'returns the most recent version for each twilio number' do
-        expect(described_class.latest_for_twilio_number).to eq([location_1_ver_2, location_1_ver_1])
+        expect(described_class.latest_for_twilio_number).to eq(
+          location_1_ver_2.twilio_number => location_1_ver_2,
+          location_1_ver_1.twilio_number => location_1_ver_1
+        )
       end
     end
 
@@ -18,7 +21,9 @@ RSpec.describe Location do
       let(:params) { { 'title' => 'New Name' } }
 
       it 'only returns the latest version of the location' do
-        expect(described_class.latest_for_twilio_number).to eq([location_1_ver_2])
+        expect(described_class.latest_for_twilio_number).to eq(
+          location_1_ver_2.twilio_number => location_1_ver_2
+        )
       end
     end
 
@@ -27,7 +32,21 @@ RSpec.describe Location do
       let!(:location_2) { create(:location, twilio_number: location_1_ver_1.twilio_number) }
 
       it 'the newer location takes precedence over the old location' do
-        expect(described_class.latest_for_twilio_number).to eq([location_2, location_1_ver_2])
+        expect(described_class.latest_for_twilio_number).to eq(
+          location_2.twilio_number => location_2,
+          location_1_ver_2.twilio_number => location_1_ver_2
+        )
+      end
+    end
+
+    context 'when a location has an online booking twilio number' do
+      let(:params) { { 'online_booking_twilio_number' => '+44999999111' } }
+
+      it 'returns a location for both twilio number and online twilio number' do
+        expect(described_class.latest_for_twilio_number).to eq(
+          location_1_ver_2.twilio_number => location_1_ver_2,
+          location_1_ver_2.online_booking_twilio_number => location_1_ver_2
+        )
       end
     end
   end

--- a/spec/views/api/v1/twilio_numbers/index.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/twilio_numbers/index.json.jbuilder_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'api/v1/twilio_numbers/index.json.jbuilder' do
   let(:location) { create(:location, booking_location: booking_location) }
 
   before do
-    assign :locations, [booking_location, location]
+    assign :locations, booking_location.twilio_number => booking_location, location.twilio_number => location
     render
   end
 


### PR DESCRIPTION
This allow online booking number to be correctly
mapped in the reporting system.