### PR TITLE
Online booking

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -12,6 +12,7 @@ class Location < ActiveRecord::Base # rubocop: disable Metrics/ClassLength
     extension
     twilio_number
     online_booking_twilio_number
+    online_booking_enabled
   ).freeze
   TP_CALL_CENTRE_NUMBER = '+442037333495'
   ORGANISATIONS = %w(cas cita nicab).freeze
@@ -47,6 +48,7 @@ class Location < ActiveRecord::Base # rubocop: disable Metrics/ClassLength
             unless: :booking_location_uid?
   validates :guiders, length: { is: 0 }, if: :booking_location_uid?
   validates :hidden, inclusion: { in: [true], if: ->(l) { l.twilio_number.blank? } }
+  validates :online_booking_enabled, inclusion: { in: [false], if: ->(l) { l.booking_location.present? } }
 
   default_scope -> { order(:title) }
   scope :current, -> { where(state: 'current') }

--- a/app/policies/location_policy.rb
+++ b/app/policies/location_policy.rb
@@ -53,7 +53,7 @@ class LocationPolicy < ApplicationPolicy
     ]
 
     base_params += [:phone] if creating_new_record? || admin?
-    base_params += [:organisation, :twilio_number, :online_booking_twilio_number] if admin?
+    base_params += [:organisation, :twilio_number, :online_booking_twilio_number, :online_booking_enabled] if admin?
 
     base_params
   end

--- a/app/views/admin/locations/_form.html.erb
+++ b/app/views/admin/locations/_form.html.erb
@@ -122,7 +122,7 @@
 </div>
 
 <% if policy(location).admin? %>
-  <div class="form-group t-visibility <%= 'form-group--error' if f.object.errors[:online_booking_enabled].any? %>" id="online_booking_enabled">
+  <div class="form-group <%= 'form-group--error' if f.object.errors[:online_booking_enabled].any? %>" id="online_booking_enabled">
     <%= f.label :online_booking_enabled, 'Online bookings?', class: 'block' %><br/>
     <%= render 'error', error_messages: location.errors[:online_booking_enabled] %>
     <%= f.radio_button :online_booking_enabled, true, class: 'l-location-status__checkbox', id: "location_online_booking_enabled_true_#{location.id}" %>

--- a/app/views/admin/locations/_form.html.erb
+++ b/app/views/admin/locations/_form.html.erb
@@ -121,6 +121,17 @@
   <%= f.label "hidden_true_#{location.id}", 'No', class: 'l-location-status__label' %>
 </div>
 
+<% if policy(location).admin? %>
+  <div class="form-group t-visibility <%= 'form-group--error' if f.object.errors[:online_booking_enabled].any? %>" id="online_booking_enabled">
+    <%= f.label :online_booking_enabled, 'Online bookings?', class: 'block' %><br/>
+    <%= render 'error', error_messages: location.errors[:online_booking_enabled] %>
+    <%= f.radio_button :online_booking_enabled, true, class: 'l-location-status__checkbox', id: "location_online_booking_enabled_true_#{location.id}" %>
+    <%= f.label "online_booking_enabled_true_#{location.id}", 'Enabled', class: 'l-location-status__label' %>
+    <%= f.radio_button :online_booking_enabled, false, class: 'l-location-status__checkbox', id: "location_online_booking_enabled_false_#{location.id}" %>
+    <%= f.label "online_booking_enabled_false_#{location.id}", 'Disabled', class: 'l-location-status__label' %>
+  </div>
+<% end %>
+
 <div class="form-group">
   <%= link_to 'Cancel', admin_location_path(location.uid), class: 'btn btn-default t-cancel-button' %>
   <%= f.submit 'Save', class: 'btn btn-success t-save-button' %>

--- a/app/views/admin/locations/_labels.html.erb
+++ b/app/views/admin/locations/_labels.html.erb
@@ -3,3 +3,6 @@
 <% else %>
   <span class="label label-danger label--inline">Booking location</span>
 <% end %>
+<% if location.canonical_location.online_booking_enabled? %>
+  <span class="label label-success label--inline">Online booking</span>
+<% end %>

--- a/app/views/admin/locations/_location.html.erb
+++ b/app/views/admin/locations/_location.html.erb
@@ -18,12 +18,26 @@
   <%- if location.booking_location %>
     <tr>
       <td>Booking location:</td>
-      <td class="t-booking-location"><%= location.booking_location.title %></td>
+      <td class="t-booking-location"><%= link_to(location.booking_location.title, admin_location_path(location.booking_location.uid)) %></td>
+    </tr>
+    <tr>
+      <td>Direct number:</td>
+      <td class="t-telephone_number"><%= location.canonical_location.phone %></td>
     </tr>
   <% else %>
     <tr>
-      <td>Telephone number:</td>
+      <td>Direct number:</td>
       <td class="t-telephone_number"><%= location.phone %></td>
+    </tr>
+  <% end %>
+  <tr>
+    <td>External number:</td>
+    <td><%= location.twilio_number %></td>
+  </tr>
+  <% if location.online_booking_twilio_number.present? %>
+    <tr>
+      <td>Online booking number:</td>
+      <td><%= location.online_booking_twilio_number %></td>
     </tr>
   <% end %>
   <tr>

--- a/app/views/admin/locations/index.html.erb
+++ b/app/views/admin/locations/index.html.erb
@@ -22,6 +22,10 @@
           <%= render 'admin/locations/labels', location: location %>
           <%= render location %>
         </div>
+        <div class="col-md-6">
+          <br>
+          <%= link_to 'Edit', edit_admin_location_path(location.uid), class: 'btn btn-default t-edit-button' %>
+        </div>
       </div>
     <% end %>
   </div>

--- a/app/views/admin/locations/show.html.erb
+++ b/app/views/admin/locations/show.html.erb
@@ -7,10 +7,17 @@
 <div class="row">
   <div class="col-md-6">
     <%= render @location %>
-  </div>
-</div>
-<div class="row">
-  <div class="col-md-6">
     <%= link_to 'Edit', edit_admin_location_path(@location.uid), class: 'btn btn-default t-edit-button' %>
+  </div>
+  <div class="col-md-6">
+    <h3>Child locations</h3>
+    <% @location.locations.current.each do |location| %>
+      <p>
+        <%= link_to admin_location_path(location.uid) do %>
+          <%= location.title %>
+          <%= '(Hidden)' if location.hidden? %>
+        <% end %>
+      </p>
+    <% end %>
   </div>
 </div>

--- a/app/views/locations/index.json.jbuilder
+++ b/app/views/locations/index.json.jbuilder
@@ -10,5 +10,6 @@ json.features @locations do |location|
     json.phone location.phone.to_s
     json.hours location.hours.to_s
     json.twilio_number location.twilio_number
+    json.online_booking_enabled location.canonical_location.online_booking_enabled
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,8 @@ en:
               inclusion: Can't be visible - additional admin needed
             hours:
               present: Leave blank when booking location exists
+            online_booking_enabled:
+              inclusion: Only booking locations can be enabled
         address:
           attributes:
             postcode:

--- a/db/migrate/20161025151439_add_online_enabled_to_location.rb
+++ b/db/migrate/20161025151439_add_online_enabled_to_location.rb
@@ -1,0 +1,5 @@
+class AddOnlineEnabledToLocation < ActiveRecord::Migration
+  def change
+    add_column :locations, :online_booking_enabled, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161012092907) do
+ActiveRecord::Schema.define(version: 20161025151439) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,6 +69,7 @@ ActiveRecord::Schema.define(version: 20161012092907) do
     t.string   "twilio_number"
     t.string   "extension"
     t.string   "online_booking_twilio_number",             default: ""
+    t.boolean  "online_booking_enabled",                   default: false
   end
 
   add_index "locations", ["booking_location_uid"], name: "index_locations_on_booking_location_uid", using: :btree

--- a/spec/factories/location.rb
+++ b/spec/factories/location.rb
@@ -12,6 +12,7 @@ FactoryGirl.define do
     hours 'MON-FRI 9am-5pm'
     booking_location nil
     editor { build(:user) }
+    online_booking_enabled false
 
     before(:create) do |location|
       if location.booking_location.present?

--- a/spec/policies/location_policy_spec.rb
+++ b/spec/policies/location_policy_spec.rb
@@ -118,7 +118,8 @@ RSpec.describe LocationPolicy do
             :phone,
             :organisation,
             :twilio_number,
-            :online_booking_twilio_number
+            :online_booking_twilio_number,
+            :online_booking_enabled
           ]
         )
       end

--- a/spec/views/locations/index.json.jbuilder_spec.rb
+++ b/spec/views/locations/index.json.jbuilder_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe 'locations/index' do
             'booking_location_id' => '',
             'phone' => location.phone,
             'hours' => 'MON-FRI 9am-5pm',
-            'twilio_number' => location.twilio_number
+            'twilio_number' => location.twilio_number,
+            'online_booking_enabled' => false
           }
         }
       ]


### PR DESCRIPTION
Allow online booking to be enabled/disabled for booking locations via the GUI.

This setting is then used in https://github.com/guidance-guarantee-programme/pension_guidance to enable/disable the online booking functionality.

Addition clean up of the interface to flag which locations are enabled and surface contact number has also been done.