### PR TITLE
Ensure guiders are copied to new location on edit

### DIFF
--- a/app/services/create_or_update_location.rb
+++ b/app/services/create_or_update_location.rb
@@ -58,8 +58,10 @@ class CreateOrUpdateLocation
   end
 
   def create_new_version(params)
+    old_location = location
     build_new_version(params)
     @location.save!
+    old_location.guiders.update_all(location_id: @location.id)
   end
 
   def previous_version_attributes

--- a/spec/services/update_location_spec.rb
+++ b/spec/services/update_location_spec.rb
@@ -36,6 +36,22 @@ RSpec.describe CreateOrUpdateLocation do
     end
 
     context 'when an existing location would be changed by the update' do
+      context 'and the location has guiders assigned to it' do
+        let!(:guider) { create(:guider, location: location) }
+
+        before do
+          subject.update(params.merge(title: 'New title'))
+        end
+
+        it 'the guiders are still assigned to the new version of the location' do
+          expect(location.current_version.guiders.pluck(:name, :email)).to eq([[guider.name, guider.email]])
+        end
+
+        it 'the guiders will no longer be assigned to the old version of the location' do
+          expect(location.guiders).to be_empty
+        end
+      end
+
       context 'when an error occurs during the creation of the new record' do
         before do
           allow(Location).to receive(:create!).and_raise(ActiveRecord::RecordInvalid)


### PR DESCRIPTION
Previously editing a location would result in all
the guiders associated with it being left associated
with the old version of the location.
