### PR TITLE
Disallow booking requests for CAB holidays

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -135,4 +135,8 @@ class Location < ApplicationRecord # rubocop: disable Metrics/ClassLength
 
     Slot.all
   end
+
+  def can_take_online_bookings?
+    online_booking_enabled? && ONLINE_BOOKING_OFFLINE.exclude?(Time.zone.today)
+  end
 end

--- a/app/models/slot.rb
+++ b/app/models/slot.rb
@@ -1,3 +1,4 @@
+
 class Slot
   Instance = Struct.new(:date, :start, :end)
 
@@ -25,7 +26,7 @@ class Slot
       booking_window_end = 6.weeks.from_now
 
       (grace_period..booking_window_end).reject do |date|
-        date.saturday? || date.sunday?
+        date.saturday? || date.sunday? || CAB_HOLIDAYS.include?(date)
       end
     end
 

--- a/app/views/locations/index.json.jbuilder
+++ b/app/views/locations/index.json.jbuilder
@@ -10,6 +10,6 @@ json.features @locations do |location|
     json.phone location.phone.to_s
     json.hours location.hours.to_s
     json.twilio_number location.twilio_number
-    json.online_booking_enabled location.canonical_location.online_booking_enabled
+    json.online_booking_enabled location.canonical_location.can_take_online_bookings?
   end
 end

--- a/config/initializers/holidays.rb
+++ b/config/initializers/holidays.rb
@@ -1,0 +1,1 @@
+CAB_HOLIDAYS = Array(Date.parse('2016/12/23')..Date.parse('2017/01/02'))

--- a/config/initializers/holidays.rb
+++ b/config/initializers/holidays.rb
@@ -1,1 +1,3 @@
 CAB_HOLIDAYS = Array(Date.parse('2016/12/23')..Date.parse('2017/01/02'))
+
+ONLINE_BOOKING_OFFLINE = Array(Date.parse('2016/12/22')..Date.parse('2017/01/01'))

--- a/spec/models/slot_spec.rb
+++ b/spec/models/slot_spec.rb
@@ -48,4 +48,17 @@ RSpec.describe Slot do
       ).to be_truthy
     end
   end
+
+  context 'the period contains a holiday' do
+    let(:date) { '2016-12-01 10:00:00' }
+    let(:holiday_period) { Date.new(2016, 12, 23)..Date.new(2017, 1, 2) }
+
+    it 'ignores the holiday dates' do
+      expect(
+        subject
+          .map { |slot| Date.parse(slot.date) }
+          .none? { |d| holiday_period.cover?(d) }
+      ).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
CAB office will be closed between 23 Dec and 2 Jan.

This is a quick fix to block these days out of the calendar.