### PR TITLE
Allow admin to search locations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'newrelic_rpm'
 gem 'plek'
 gem 'pundit'
 gem 'uk_postcode'
+gem 'select2-rails'
 
 group :development, :test do
   gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,6 +268,8 @@ GEM
     sdoc (0.4.2)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    select2-rails (4.0.3)
+      thor (~> 0.14)
     site_prism (2.9)
       addressable (>= 2.3.3, < 3.0)
       capybara (>= 2.1, < 3.0)
@@ -348,6 +350,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   scss-lint
   sdoc (~> 0.4.0)
+  select2-rails
   site_prism
   turbolinks
   uglifier (>= 1.3.0)

--- a/app/assets/javascripts/admin/application.js
+++ b/app/assets/javascripts/admin/application.js
@@ -14,3 +14,5 @@
 //= require jquery_ujs
 //= require turbolinks
 //= require ./locations-directory
+//= require select2
+//= require ./search

--- a/app/assets/javascripts/admin/search.js
+++ b/app/assets/javascripts/admin/search.js
@@ -1,0 +1,22 @@
+$(function() {
+  'use strict';
+
+  function formatLocation(location) {
+    if (location.text === '' || location.element === undefined) {
+      return null;
+    }
+
+    var className = $(location.element).data('hidden') ? 'location__hidden' : 'location__visible';
+
+    return $('<div class="' + className + '">' + location.text + '</div>');
+  }
+
+  $('#search')
+    .select2({
+      templateResult: formatLocation,
+      templateSelection: formatLocation
+    })
+    .on('change', function() {
+      window.location = '/admin/locations/' + $(this).val();
+    });
+});

--- a/app/assets/stylesheets/admin/application.scss
+++ b/app/assets/stylesheets/admin/application.scss
@@ -6,8 +6,11 @@
 @import "./components/error-summary";
 @import "./components/form-group";
 @import "./components/label";
+@import "./components/location";
 @import "./components/location-details-table";
 @import "./components/pagination-atoz";
 
 @import "./layout/filter-form";
 @import "./layout/location-status";
+@import "select2";
+@import "select2-bootstrap";

--- a/app/assets/stylesheets/admin/components/_location.scss
+++ b/app/assets/stylesheets/admin/components/_location.scss
@@ -1,0 +1,17 @@
+// scss-lint:disable PlaceholderInExtend
+.location__visible:before {
+  @extend .glyphicon;
+  @extend .glyphicon-eye-open;
+
+  padding-right: 3px;
+  color: $visible-location;
+}
+
+.location__hidden:before {
+  @extend .glyphicon;
+  @extend .glyphicon-eye-close;
+
+  padding-right: 3px;
+  color: $hidden-location;
+}
+// scss-lint:enable PlaceholderInExtend

--- a/app/assets/stylesheets/admin/lib/_variables.scss
+++ b/app/assets/stylesheets/admin/lib/_variables.scss
@@ -41,3 +41,7 @@ $location-status-not-selected: $color-grey-rolling-stone;
 $location-status-selected: $color-black;
 
 $fixed-width-for-telephone-number: 140px;
+
+//location visibility
+$visible-location: $color-green-atlantis;
+$hidden-location: $color-razmatazz;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,4 +21,8 @@ module ApplicationHelper
       .inject(&:merge)
       .sort_by(&:first)
   end
+
+  def location_visibility_class(location)
+    location.hidden? ? 'location__hidden' : 'location__visible'
+  end
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -53,7 +53,7 @@ class Location < ApplicationRecord # rubocop: disable Metrics/ClassLength
   default_scope -> { order(:title) }
   scope :current, -> { where(state: 'current') }
   scope :active, -> { where(hidden: false) }
-
+  scope :current_by_visibility, -> { current.reorder(:hidden, :title) }
   class << self
     def booking_location_for(uid)
       location = includes(:locations, :guiders)

--- a/app/views/admin/locations/_location.html.erb
+++ b/app/views/admin/locations/_location.html.erb
@@ -18,7 +18,9 @@
   <%- if location.booking_location %>
     <tr>
       <td>Booking location:</td>
-      <td class="t-booking-location"><%= link_to(location.booking_location.title, admin_location_path(location.booking_location.uid)) %></td>
+      <td class="t-booking-location <%= location_visibility_class(location.booking_location) %>">
+        <%= link_to(location.booking_location.title, admin_location_path(location.booking_location.uid)) %>
+      </td>
     </tr>
     <tr>
       <td>Direct number:</td>
@@ -42,7 +44,9 @@
   <% end %>
   <tr>
     <td>Status:</td>
-    <td class="t-visibility"><%= location.hidden ? 'Hidden' : 'Active' %></td>
+    <td class="t-visibility <%= location_visibility_class(location) %>">
+      <%= location.hidden ? 'Hidden' : 'Active' %>
+    </td>
   </tr>
   <tr>
     <td>Last updated:</td>

--- a/app/views/admin/locations/show.html.erb
+++ b/app/views/admin/locations/show.html.erb
@@ -33,11 +33,10 @@
   </div>
   <div class="col-md-6">
     <h3>Child locations</h3>
-    <% @location.locations.current.each do |location| %>
+    <% @location.locations.current_by_visibility.each do |location| %>
       <p>
-        <%= link_to admin_location_path(location.uid) do %>
+        <%= link_to admin_location_path(location.uid), class: location_visibility_class(location) do %>
           <%= location.title %>
-          <%= '(Hidden)' if location.hidden? %>
         <% end %>
       </p>
     <% end %>

--- a/app/views/layouts/admin/application.html.erb
+++ b/app/views/layouts/admin/application.html.erb
@@ -15,6 +15,19 @@
   <li>
     <%= link_to 'Directory', admin_locations_path %>
   </li>
+  <li>
+    <p style="color: #bfbfbf; padding-top: 13px;">
+      Search
+      <%=
+        select_tag(
+          :search,
+          options_for_select(Location.current_by_visibility.map { |l| [l.title, l.uid, 'data-hidden' => l.hidden?] }, @location&.uid),
+          class: 'input-md-3',
+          include_blank: true
+        )
+      %>
+    </p>
+  </li>
 <% end %>
 
 <% content_for(:content) do %>

--- a/features/admin_location.feature
+++ b/features/admin_location.feature
@@ -56,12 +56,12 @@ Feature: Admin - Location Directory
 
   Scenario: I can make a location with a twilio number visible
     Given a hidden location exists with a twilio number
-    When I toggle the locations visiblity
+    When I toggle the location's visibility
     Then the location is visible
 
   Scenario: I can not make a location without a twilio number visible
     Given a hidden location exists without a twilio number
-    When I toggle the locations visiblity
+    When I toggle the location's visibility
     Then I get a permission denied error
     And the location is hidden
 

--- a/features/step_definitions/admin/create_location_steps.rb
+++ b/features/step_definitions/admin/create_location_steps.rb
@@ -51,7 +51,7 @@ Given(/^a hidden location exists with a twilio number$/) do
   @location = create(:location, twilio_number: '+442712345678', hidden: true)
 end
 
-When(/^I toggle the locations visiblity$/) do
+When(/^I toggle the location's visibility$/) do
   @page = AdminEditLocationPage.new
   @page.load(uid: @location.uid)
 


### PR DESCRIPTION
Use select2 to allow quick search and jump to
a location. In addition colour icons have been
to identify a location visibility.

Green open eye for active locations
Red closed eye for hidden locations

I'm not 100% sure on the green but it's the one currently in our palette:
![screenshot 2016-12-07 09 20 31](https://cloud.githubusercontent.com/assets/63736/20961776/84d2f49c-bc5e-11e6-861c-b695ee7a5c98.png)
