### PR TITLE
Handle multiple results from geocoder lookup

### DIFF
--- a/app/models/postcode_geocoder.rb
+++ b/app/models/postcode_geocoder.rb
@@ -2,22 +2,21 @@ require 'geocoder'
 
 class PostcodeGeocoder
   def initialize(postcode)
-    @geocodes = Geocoder.search(postcode)
+    @geocodes = filter_postal_code_result(Geocoder.search(postcode))
   end
 
   def valid?
-    if @geocodes.empty?
-      false
-    elsif @geocodes.count == 1
-      @geocodes.first.data['address_components'].any? { |a| a['types'] == ['postal_code'] }
-    else
-      # add functionality to handle multiple results
-      false
-    end
+    @geocodes.count == 1
   end
 
   def coordinates
     geocode = @geocodes.first
     [geocode.longitude, geocode.latitude]
+  end
+
+  def filter_postal_code_result(geocodes)
+    geocodes.select do |geocode|
+      geocode.data['address_components'].any? { |a| a['types'] == ['postal_code'] }
+    end
   end
 end

--- a/features/admin_location.feature
+++ b/features/admin_location.feature
@@ -41,6 +41,7 @@ Feature: Admin - Location Directory
       | set    | town             | Test vale              |
       | set    | county           | Testland               |
       | set    | postcode         | PR1 2NJ                |
+      | set    | postcode         | LA6 2BG                |
 
   Scenario: A new location version is created when the location is edited
     Given a location exists called "Apples"

--- a/features/cassettes/Admin_-_Location_Directory/Editing_a_locations_address_creates_a_new_version_with_the_updated_values/_set_postcode_LA6_2BG_.yml
+++ b/features/cassettes/Admin_-_Location_Directory/Editing_a_locations_address_creates_a_new_version_with_the_updated_values/_set_postcode_LA6_2BG_.yml
@@ -1,0 +1,173 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=LA6%202BG&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 20 Jan 2017 15:26:08 GMT
+      Expires:
+      - Sat, 21 Jan 2017 15:26:08 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '689'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "LA6 2BG",
+                       "short_name" : "LA6 2BG",
+                       "types" : [ "postal_code" ]
+                    },
+                    {
+                       "long_name" : "Bective Road",
+                       "short_name" : "Bective Rd",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Kirkby Lonsdale",
+                       "short_name" : "Kirkby Lonsdale",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Carnforth",
+                       "short_name" : "Carnforth",
+                       "types" : [ "postal_town" ]
+                    },
+                    {
+                       "long_name" : "Cumbria",
+                       "short_name" : "Cumbria",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "England",
+                       "short_name" : "England",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "United Kingdom",
+                       "short_name" : "GB",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "Bective Rd, Kirkby Lonsdale, Carnforth LA6 2BG, UK",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 54.2027558,
+                          "lng" : -2.5986924
+                       },
+                       "southwest" : {
+                          "lat" : 54.20209149999999,
+                          "lng" : -2.6000472
+                       }
+                    },
+                    "location" : {
+                       "lat" : 54.2023933,
+                       "lng" : -2.5994648
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 54.2037726302915,
+                          "lng" : -2.598020819708498
+                       },
+                       "southwest" : {
+                          "lat" : 54.2010746697085,
+                          "lng" : -2.600718780291502
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJh0FcX0yGfEgR4W155B1p8c4",
+                 "types" : [ "postal_code" ]
+              },
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "LA6",
+                       "short_name" : "LA6",
+                       "types" : [ "postal_code", "postal_code_prefix" ]
+                    },
+                    {
+                       "long_name" : "Carnforth",
+                       "short_name" : "Carnforth",
+                       "types" : [ "postal_town" ]
+                    },
+                    {
+                       "long_name" : "England",
+                       "short_name" : "England",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "United Kingdom",
+                       "short_name" : "GB",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "Carnforth LA6, UK",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 54.3050584,
+                          "lng" : -2.2913678
+                       },
+                       "southwest" : {
+                          "lat" : 54.0869345,
+                          "lng" : -2.7717273
+                       }
+                    },
+                    "location" : {
+                       "lat" : 54.1877639,
+                       "lng" : -2.5946545
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 54.3050584,
+                          "lng" : -2.2913678
+                       },
+                       "southwest" : {
+                          "lat" : 54.0869345,
+                          "lng" : -2.7717273
+                       }
+                    }
+                 },
+                 "partial_match" : true,
+                 "place_id" : "ChIJYUuY87ZifEgRFhu3aahZXos",
+                 "types" : [ "postal_code", "postal_code_prefix" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version:
+  recorded_at: Fri, 20 Jan 2017 15:26:08 GMT
+recorded_with: VCR 3.0.3

--- a/spec/models/postcode_geocoder_spec.rb
+++ b/spec/models/postcode_geocoder_spec.rb
@@ -52,13 +52,25 @@ RSpec.describe PostcodeGeocoder do
       end
     end
 
-    context 'when geocoder returns multiple results' do
-      before do
-        allow(Geocoder).to receive(:search).and_return([valid_geocode, invalid_geocode])
+    context 'when geocoder has multiple results' do
+      context 'and exactly one of the is a postcode address component' do
+        before do
+          allow(Geocoder).to receive(:search).and_return([valid_geocode, invalid_geocode])
+        end
+
+        it 'is valid' do
+          expect(subject).to be_valid
+        end
       end
 
-      it 'is not valid' do
-        expect(subject).not_to be_valid
+      context 'and multiple are postcode address components' do
+        before do
+          allow(Geocoder).to receive(:search).and_return([valid_geocode, valid_geocode])
+        end
+
+        it 'is not valid' do
+          expect(subject).not_to be_valid
+        end
       end
     end
   end


### PR DESCRIPTION
Filter results returned from postcode geocoding
to only care when type is ['postal_code'].

This fixes the only occurance of this bug for
'LG6 2BG'. This process will still fail if multiple
results are returned which have a type of
['postal_code'].