### PR TITLE
Permit first coordinates if there are multiple

### DIFF
--- a/app/models/postcode_geocoder.rb
+++ b/app/models/postcode_geocoder.rb
@@ -6,7 +6,7 @@ class PostcodeGeocoder
   end
 
   def valid?
-    @geocodes.count == 1
+    @geocodes.count.positive?
   end
 
   def coordinates

--- a/spec/models/postcode_geocoder_spec.rb
+++ b/spec/models/postcode_geocoder_spec.rb
@@ -68,8 +68,8 @@ RSpec.describe PostcodeGeocoder do
           allow(Geocoder).to receive(:search).and_return([valid_geocode, valid_geocode])
         end
 
-        it 'is not valid' do
-          expect(subject).not_to be_valid
+        it 'is valid' do
+          expect(subject).to be_valid
         end
       end
     end

--- a/spec/models/postcode_geocoder_spec.rb
+++ b/spec/models/postcode_geocoder_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe PostcodeGeocoder do
           allow(Geocoder).to receive(:search).and_return([valid_geocode])
         end
 
-        it 'is not valid' do
+        it 'is valid' do
           expect(subject).to be_valid
         end
       end


### PR DESCRIPTION
This isn't entirely fool proof but rather than stating these are invalid
and not permitting the user to proceed, we can just accept the first set of
coordinates and move along. In practice the actual gaps between coordinates
are so trivially small that picking the first is usually the right thing to
do.