### PR TITLE
Allow children to opt out of online booking

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -48,7 +48,7 @@ class Location < ApplicationRecord # rubocop: disable Metrics/ClassLength
             unless: :booking_location_uid?
   validates :guiders, length: { is: 0 }, if: :booking_location_uid?
   validates :hidden, inclusion: { in: [true], if: ->(l) { l.twilio_number.blank? } }
-  validates :online_booking_enabled, inclusion: { in: [false], if: ->(l) { l.booking_location.present? } }
+  validates :online_booking_enabled, inclusion: { in: [true, false] }
 
   default_scope -> { order(:title) }
   scope :current, -> { where(state: 'current') }
@@ -134,9 +134,5 @@ class Location < ApplicationRecord # rubocop: disable Metrics/ClassLength
     return [] if booking_location_uid.present?
 
     Slot.all
-  end
-
-  def can_take_online_bookings?
-    online_booking_enabled? && ONLINE_BOOKING_OFFLINE.exclude?(Time.zone.today)
   end
 end

--- a/app/views/admin/locations/_labels.html.erb
+++ b/app/views/admin/locations/_labels.html.erb
@@ -3,6 +3,6 @@
 <% else %>
   <span class="label label-danger label--inline">Booking location</span>
 <% end %>
-<% if location.canonical_location.online_booking_enabled? %>
+<% if location.online_booking_enabled? %>
   <span class="label label-success label--inline">Online booking</span>
 <% end %>

--- a/app/views/locations/index.json.jbuilder
+++ b/app/views/locations/index.json.jbuilder
@@ -10,6 +10,6 @@ json.features @locations do |location|
     json.phone location.phone.to_s
     json.hours location.hours.to_s
     json.twilio_number location.twilio_number
-    json.online_booking_enabled location.canonical_location.can_take_online_bookings?
+    json.online_booking_enabled location.online_booking_enabled
   end
 end

--- a/config/initializers/holidays.rb
+++ b/config/initializers/holidays.rb
@@ -1,3 +1,1 @@
 CAB_HOLIDAYS = Array(Date.parse('2016/12/23')..Date.parse('2017/01/02'))
-
-ONLINE_BOOKING_OFFLINE = Array(Date.parse('2016/12/22')..Date.parse('2017/01/01'))

--- a/db/migrate/20170216111618_correct_child_booking_enabled.rb
+++ b/db/migrate/20170216111618_correct_child_booking_enabled.rb
@@ -1,0 +1,20 @@
+class CorrectChildBookingEnabled < ActiveRecord::Migration[5.0]
+  def up
+    booking_locations = Location.current.active.where(
+      booking_location_uid: nil,
+      online_booking_enabled: true
+    )
+
+    puts "Correcting #{booking_locations.count} booking locations"
+
+    booking_locations.each do |booking_location|
+      children = booking_location.locations.current.active
+
+      children.update_all(online_booking_enabled: true)
+    end
+  end
+
+  def down
+    # noop
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161025151439) do
+ActiveRecord::Schema.define(version: 20170216111618) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,9 +45,8 @@ ActiveRecord::Schema.define(version: 20161025151439) do
     t.integer  "location_id"
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
+    t.index ["location_id"], name: "index_guiders_on_location_id", using: :btree
   end
-
-  add_index "guiders", ["location_id"], name: "index_guiders_on_location_id", using: :btree
 
   create_table "locations", force: :cascade do |t|
     t.string   "uid"
@@ -70,9 +68,8 @@ ActiveRecord::Schema.define(version: 20161025151439) do
     t.string   "extension"
     t.string   "online_booking_twilio_number",             default: ""
     t.boolean  "online_booking_enabled",                   default: false
+    t.index ["booking_location_uid"], name: "index_locations_on_booking_location_uid", using: :btree
   end
-
-  add_index "locations", ["booking_location_uid"], name: "index_locations_on_booking_location_uid", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "name"


### PR DESCRIPTION
Online bookings for locations was previously controlled by the booking
location or parent location being enabled for online bookings. This
change allows us to specify that the booking location itself is enabled
for booking, but also whether individual children are enabled.

This change required a migration to blanket apply the
`online_booking_enabled` flag to existing child locations with booking
locations also enabled for online bookings already since previously the
flag was inferred from the parent as previously stated.