### PR TITLE
[WIP] Allow locations to filter slots by cut-off date

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -131,8 +131,6 @@ class Location < ApplicationRecord # rubocop: disable Metrics/ClassLength
   end
 
   def slots
-    return [] if booking_location_uid.present?
-
     Slot.all
   end
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -131,6 +131,6 @@ class Location < ApplicationRecord # rubocop: disable Metrics/ClassLength
   end
 
   def slots
-    Slot.all
+    Slot.all(cut_off_from)
   end
 end

--- a/app/models/slot.rb
+++ b/app/models/slot.rb
@@ -10,8 +10,8 @@ class Slot
   }.freeze
 
   class << self
-    def all
-      slot_dates.map do |date|
+    def all(cut_off_from = nil)
+      slot_dates(cut_off_from).map do |date|
         [
           Instance.new(date.iso8601, '0900', '1300'),
           Instance.new(date.iso8601, '1300', '1700')
@@ -21,11 +21,11 @@ class Slot
 
     private
 
-    def slot_dates
+    def slot_dates(cut_off_from)
       booking_window_end = 6.weeks.from_now
 
       (grace_period..booking_window_end).reject do |date|
-        date.saturday? || date.sunday?
+        date.saturday? || date.sunday? || cut_off_from && date >= cut_off_from
       end
     end
 

--- a/app/models/slot.rb
+++ b/app/models/slot.rb
@@ -1,4 +1,3 @@
-
 class Slot
   Instance = Struct.new(:date, :start, :end)
 
@@ -26,7 +25,7 @@ class Slot
       booking_window_end = 6.weeks.from_now
 
       (grace_period..booking_window_end).reject do |date|
-        date.saturday? || date.sunday? || CAB_HOLIDAYS.include?(date)
+        date.saturday? || date.sunday?
       end
     end
 

--- a/app/views/api/v1/booking_locations/_booking_location.json.jbuilder
+++ b/app/views/api/v1/booking_locations/_booking_location.json.jbuilder
@@ -2,6 +2,13 @@ json.uid location.uid
 json.name location.title
 json.address location.address_line
 json.online_booking_twilio_number location.online_booking_twilio_number
+
+json.slots location.slots do |slot|
+  json.date slot.date
+  json.start slot.start
+  json.end slot.end
+end
+
 json.locations location.locations.active.current do |child|
   json.partial! 'booking_location', location: child
 end

--- a/app/views/api/v1/booking_locations/show.json.jbuilder
+++ b/app/views/api/v1/booking_locations/show.json.jbuilder
@@ -5,9 +5,3 @@ json.guiders @location.guiders do |guider|
   json.name guider.name
   json.email guider.email
 end
-
-json.slots @location.slots do |slot|
-  json.date slot.date
-  json.start slot.start
-  json.end slot.end
-end

--- a/config/initializers/holidays.rb
+++ b/config/initializers/holidays.rb
@@ -1,1 +1,0 @@
-CAB_HOLIDAYS = Array(Date.parse('2016/12/23')..Date.parse('2017/01/02'))

--- a/db/migrate/20170228100601_add_cut_off_from_to_locations.rb
+++ b/db/migrate/20170228100601_add_cut_off_from_to_locations.rb
@@ -1,0 +1,5 @@
+class AddCutOffFromToLocations < ActiveRecord::Migration[5.0]
+  def change
+    add_column :locations, :cut_off_from, :date, null: true
+  end
+end

--- a/db/migrate/20170228103213_set_location_slot_cut_off_dates.rb
+++ b/db/migrate/20170228103213_set_location_slot_cut_off_dates.rb
@@ -1,0 +1,31 @@
+class SetLocationSlotCutOffDates < ActiveRecord::Migration[5.0]
+  def up
+    locations_to_close = %w(
+      01564919-9cf2-43ed-ac2a-91a33e5e81ea
+      2044b7e6-c819-43a8-8c3f-f239c9a28aa6
+      77d003f9-976d-4eb2-8703-715b698b96d4
+      ddc5113c-fb17-4cdb-be0e-76900446fb14
+      d38d399a-db2b-49cd-b50a-1804f02b52de
+      c481d0a6-dccb-4f52-bfa0-57aba00a2560
+      266ba3bc-768d-4184-a79f-104277e87b08
+      271e70b9-27b0-4c56-910b-feca5530a3a0
+      888dacac-fdbd-4ce6-9344-396b380567ea
+      df2361e6-e17f-4448-a8b4-7214d7b8bd43
+      49d362a8-e36e-4f88-b41f-6b982566b7d6
+      7f1acc30-8a35-48d2-aed0-64ab745ec079
+      6a5ac806-6476-4fd2-9c08-87a6a100b359
+      585473d8-6227-45f1-aa7d-dc01bbe8db7b
+      ce33c3ba-0dbc-452d-85eb-fd96d759431c
+      2fd87784-c67f-44dc-87f0-615412a731f0
+      872068bf-f521-4b3b-a7b5-dd834422854e
+      91ec2400-7653-44a7-b218-16722a939a23
+      5e26a381-eedd-413e-b30e-4c05528efaec
+    ).freeze
+
+    Location.current.active.where(uid: locations_to_close).update_all(cut_off_from: '2017-04-01')
+  end
+
+  def down
+    # noop
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170216111618) do
+ActiveRecord::Schema.define(version: 20170228100601) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -68,6 +68,7 @@ ActiveRecord::Schema.define(version: 20170216111618) do
     t.string   "extension"
     t.string   "online_booking_twilio_number",             default: ""
     t.boolean  "online_booking_enabled",                   default: false
+    t.date     "cut_off_from"
     t.index ["booking_location_uid"], name: "index_locations_on_booking_location_uid", using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170228100601) do
+ActiveRecord::Schema.define(version: 20170228103213) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -75,8 +75,8 @@ RSpec.describe Location do
     context 'for a non-booking location' do
       let(:location) { build(:location, booking_location_uid: 'deadbeef') }
 
-      it 'returns an empty array' do
-        expect(location.slots).to eq([])
+      it 'returns the slots' do
+        expect(location.slots).to_not be_empty
       end
     end
 

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -81,11 +81,23 @@ RSpec.describe Location do
     end
 
     context 'for a booking location' do
-      let(:location) { build(:location) }
+      subject do
+        travel_to('2016-06-07 10:00:00') { location.slots }
+      end
 
-      it 'returns slots' do
-        travel_to '2016-06-07 10:00:00' do
-          expect(location.slots).to_not be_empty
+      context 'when no cut-off date exists' do
+        let(:location) { build(:location) }
+
+        it 'returns slots' do
+          expect(subject).to_not be_empty
+        end
+      end
+
+      context 'when a cut-off date exists' do
+        let(:location) { build(:location, cut_off_from: '2016-06-23') }
+
+        it 'only returns slots after the cut-off date' do
+          expect(subject.last.date).to eq('2016-06-22')
         end
       end
     end

--- a/spec/models/slot_spec.rb
+++ b/spec/models/slot_spec.rb
@@ -48,17 +48,4 @@ RSpec.describe Slot do
       ).to be_truthy
     end
   end
-
-  context 'the period contains a holiday' do
-    let(:date) { '2016-12-01 10:00:00' }
-    let(:holiday_period) { Date.new(2016, 12, 23)..Date.new(2017, 1, 2) }
-
-    it 'ignores the holiday dates' do
-      expect(
-        subject
-          .map { |slot| Date.parse(slot.date) }
-          .none? { |d| holiday_period.cover?(d) }
-      ).to be_truthy
-    end
-  end
 end

--- a/spec/views/api/v1/booking_locations/show.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/booking_locations/show.json.jbuilder_spec.rb
@@ -21,12 +21,17 @@ RSpec.describe 'api/v1/booking_locations/show.json.jbuilder' do
       'online_booking_twilio_number' => booking_location.online_booking_twilio_number
     )
 
-    expect(subject['locations'].first).to eq(
+    expect(subject['locations'].first).to include(
       'uid' => booking_location.locations.first.uid,
       'name' => booking_location.locations.first.title,
       'address' => booking_location.locations.first.address_line,
       'online_booking_twilio_number' => '',
-      'locations' => []
+      'locations' => [],
+      'slots' => a_hash_including(
+        'date' => '2016-06-09',
+        'start' => '0900',
+        'end' => '1300'
+      )
     )
 
     expect(subject['slots'].first).to eq(


### PR DESCRIPTION
Best reviewed commit-by-commit.

When the `cut_off_from` date stamp is present on a particular location, the
location will filter its slots to ensure none are present after the given
cut off.

Before merging:

- [x] Modify `booking_locations` to handle new payload
- [x] Modify `pension_guidance` to handle new payload