### PR TITLE
Add validation on the online booking twilio number

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -43,9 +43,10 @@ class Location < ApplicationRecord # rubocop: disable Metrics/ClassLength
             uk_phone_number: true,
             if: :current_with_twilio_number?
   validates :online_booking_twilio_number,
-            uk_phone_number: true,
-            allow_blank: true,
-            unless: :booking_location_uid?
+            presence: true,
+            uk_phone_number: { allow_blank: true },
+            unless: :booking_location_uid?,
+            if: :online_booking_enabled?
   validates :guiders, length: { is: 0 }, if: :booking_location_uid?
   validates :hidden, inclusion: { in: [true], if: ->(l) { l.twilio_number.blank? } }
   validates :online_booking_enabled, inclusion: { in: [true, false] }

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -169,6 +169,83 @@ RSpec.describe Location do
     expect(location).to be_valid
   end
 
+  describe '#online_booking_twilio_number' do
+    let(:location) do
+      build :location do |location|
+        location.booking_location = booking_location
+        location.online_booking_enabled = online_booking_enabled
+        location.online_booking_twilio_number = online_booking_twilio_number
+      end
+    end
+
+    subject { location.errors[:online_booking_twilio_number] }
+
+    context 'when online booking is enabled' do
+      let(:online_booking_enabled) { true }
+
+      context 'and the location has a parent location' do
+        let(:booking_location) { create(:location) }
+
+        context 'and the online booking twilio number is absent' do
+          let(:online_booking_twilio_number) { nil }
+          before { location.valid? }
+
+          it 'is has no errors' do
+            expect(subject).to be_empty
+          end
+        end
+      end
+
+      context 'and the location has no parent location' do
+        let(:booking_location) { nil }
+
+        context 'and the online booking twilio number is absent' do
+          let(:online_booking_twilio_number) { nil }
+          before { location.valid? }
+
+          it 'is has errors' do
+            expect(subject).to be_present
+          end
+        end
+
+        context 'and the online booking twilio number is present' do
+          let(:online_booking_twilio_number) { '+441111112222' }
+          before { location.valid? }
+
+          it 'is has no errors' do
+            expect(subject).to be_empty
+          end
+        end
+      end
+    end
+
+    context 'when online booking is disabled' do
+      let(:online_booking_enabled) { false }
+
+      context 'and the online booking twilio number is absent' do
+        let(:online_booking_twilio_number) { nil }
+
+        context 'and the location has a parent location' do
+          let(:booking_location) { create(:location) }
+          before { location.valid? }
+
+          it 'is has no errors' do
+            expect(subject).to be_empty
+          end
+        end
+
+        context 'and the location has no parent location' do
+          let(:booking_location) { nil }
+          before { location.valid? }
+
+          it 'is has no errors' do
+            expect(subject).to be_empty
+          end
+        end
+      end
+    end
+  end
+
   describe 'editing the phone number' do
     let(:version_3) do
       build(:location, uid: '12345', version: 3, phone: '+44123456111', twilio_number: '+44987654321', state: 'old')


### PR DESCRIPTION
Adding a presence requirement that applies when online booking is enabled and there is no parent location.

`allow_blank` added to the format check so as not to have it return an invalid error in addition to failing the presence check.

Don't hugely like the repeated calls to `location.valid?` in the specs, but decided  to target the specific field's errors (rather than trying to also be able to call `be_valid`) to mitigate all the other validation going, so had sequence of events issues when it came to managing assignment of test values.