### PR TITLE
Include hidden / inactive locations in response

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -55,6 +55,7 @@ class Location < ApplicationRecord # rubocop: disable Metrics/ClassLength
   scope :current, -> { where(state: 'current') }
   scope :active, -> { where(hidden: false) }
   scope :current_by_visibility, -> { current.reorder(:hidden, :title) }
+
   class << self
     def booking_location_for(uid)
       location = includes(:locations, :guiders)

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -60,7 +60,6 @@ class Location < ApplicationRecord # rubocop: disable Metrics/ClassLength
     def booking_location_for(uid)
       location = includes(:locations, :guiders)
                  .current
-                 .active
                  .find_by(uid: uid)
 
       location&.canonical_location

--- a/app/views/api/v1/booking_locations/_booking_location.json.jbuilder
+++ b/app/views/api/v1/booking_locations/_booking_location.json.jbuilder
@@ -2,6 +2,7 @@ json.uid location.uid
 json.name location.title
 json.address location.address_line
 json.online_booking_twilio_number location.online_booking_twilio_number
+json.hidden location.hidden
 
 json.slots location.slots do |slot|
   json.date slot.date
@@ -9,6 +10,6 @@ json.slots location.slots do |slot|
   json.end slot.end
 end
 
-json.locations location.locations.active.current do |child|
+json.locations location.locations.current do |child|
   json.partial! 'booking_location', location: child
 end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -143,8 +143,8 @@ RSpec.describe Location do
         booking_location.update_attribute(:hidden, true)
       end
 
-      it 'returns only active versions' do
-        expect(subject).to be_nil
+      it 'returns the inactive version' do
+        expect(subject).to eq(booking_location)
       end
     end
   end

--- a/spec/views/api/v1/booking_locations/show.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/booking_locations/show.json.jbuilder_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe 'api/v1/booking_locations/show.json.jbuilder' do
       'uid' => booking_location.uid,
       'name' => booking_location.title,
       'address' => booking_location.address_line,
-      'online_booking_twilio_number' => booking_location.online_booking_twilio_number
+      'online_booking_twilio_number' => booking_location.online_booking_twilio_number,
+      'hidden' => booking_location.hidden
     )
 
     expect(subject['locations'].first).to include(
@@ -26,6 +27,7 @@ RSpec.describe 'api/v1/booking_locations/show.json.jbuilder' do
       'name' => booking_location.locations.first.title,
       'address' => booking_location.locations.first.address_line,
       'online_booking_twilio_number' => '',
+      'hidden' => booking_location.locations.first.hidden,
       'locations' => [],
       'slots' => a_hash_including(
         'date' => '2016-06-09',


### PR DESCRIPTION
We need to include hidden locations in the booking location API response to
insulate against changes being made to the size and structure of booking
locations and their respective child locations.

This isn't such an issue when used from the frontend's perspective but
causes lots of issues when planner refers to locations that no longer
'exist' in the API-sense.

![screen shot 2017-03-08 at 13 53 50](https://cloud.githubusercontent.com/assets/41963/23707547/b7e3d448-040a-11e7-9e25-7cd8ae0cf7bf.png)
