### PR TITLE
Correct current and hidden records

### DIFF
--- a/db/migrate/20170309145932_correct_hidden_current_locations.rb
+++ b/db/migrate/20170309145932_correct_hidden_current_locations.rb
@@ -1,0 +1,9 @@
+class CorrectHiddenCurrentLocations < ActiveRecord::Migration[5.0]
+  def up
+    Location.current.where(hidden: true).update_all(state: 'old')
+  end
+
+  def down
+    # noop
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170303133843) do
+ActiveRecord::Schema.define(version: 20170309145932) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Alterations to the booking locations API mean we now include hidden
locations by default to maintain data integrity during the upcoming
moves. We noticed ~190 records that were incorrectly marked both
'current' and 'hidden' meaning they were returned and
displayed in planner and elsewhere that relies on this particular API.

This change ensures these locations will not be returned in the booking
locations API.