### PR TITLE
Begin conversion of `guiders` association

### DIFF
--- a/app/models/guider.rb
+++ b/app/models/guider.rb
@@ -1,3 +1,6 @@
 class Guider < ApplicationRecord
   belongs_to :location
+
+  has_many :guider_assignments
+  has_many :locations, through: :guider_assignments
 end

--- a/app/models/guider_assignment.rb
+++ b/app/models/guider_assignment.rb
@@ -1,0 +1,4 @@
+class GuiderAssignment < ApplicationRecord
+  belongs_to :guider
+  belongs_to :location
+end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -26,6 +26,8 @@ class Location < ApplicationRecord # rubocop: disable Metrics/ClassLength
   has_many :locations, foreign_key: :booking_location_uid, primary_key: :uid
   has_many :guiders
 
+  has_many :guider_assignments
+
   validates :uid, presence: true
   validates :organisation, presence: true, inclusion: ORGANISATIONS
   validates :title, presence: true

--- a/db/migrate/20170314101829_create_guider_assignments.rb
+++ b/db/migrate/20170314101829_create_guider_assignments.rb
@@ -1,0 +1,24 @@
+class CreateGuiderAssignments < ActiveRecord::Migration[5.0]
+  def up
+    create_table :guider_assignments do |t|
+      t.belongs_to :guider, null: false
+      t.belongs_to :location, null: false
+      t.timestamps null: false
+
+      t.index %i(guider_id location_id), unique: true
+    end
+
+    say_with_time 'Creating the necessary guider assignments' do
+      Guider.pluck(:id, :location_id).each do |attributes|
+        GuiderAssignment.create!(
+          guider_id: attributes.first,
+          location_id: attributes.last
+        )
+      end
+    end
+  end
+
+  def down
+    drop_table :guider_assignments
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170309145932) do
+ActiveRecord::Schema.define(version: 20170314101829) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,6 +37,16 @@ ActiveRecord::Schema.define(version: 20170309145932) do
     t.string   "phone"
     t.datetime "created_at",    null: false
     t.datetime "updated_at",    null: false
+  end
+
+  create_table "guider_assignments", force: :cascade do |t|
+    t.integer  "guider_id",   null: false
+    t.integer  "location_id", null: false
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+    t.index ["guider_id", "location_id"], name: "index_guider_assignments_on_guider_id_and_location_id", unique: true, using: :btree
+    t.index ["guider_id"], name: "index_guider_assignments_on_guider_id", using: :btree
+    t.index ["location_id"], name: "index_guider_assignments_on_location_id", using: :btree
   end
 
   create_table "guiders", force: :cascade do |t|


### PR DESCRIPTION
We're converting the `guiders` association from `has_many` to
`has_many through:` to allow us to assign guiders to multiple
locations. This is to support the reassignment of child locations to
booking locations.

When a child moves to a new parent it needs to bring with it the
associated guiders for the parent location to maintain data integrity
via the booking locations API.

This processed is stepped as we are migrating from a typical
`belongs_to` to a join table approach and this cannot be migrated in a
single atomic step.