### PR TITLE
Allow guiders to belong to multiple locations

### DIFF
--- a/app/controllers/admin/guiders_controller.rb
+++ b/app/controllers/admin/guiders_controller.rb
@@ -1,6 +1,7 @@
 module Admin
   class GuidersController < Admin::BaseController
-    before_action :set_authorised_location, :set_guider
+    before_action :set_authorised_location
+    before_action :set_guider, except: :create
 
     def index
       @guiders = @location.guiders
@@ -19,7 +20,7 @@ module Admin
     end
 
     def set_guider
-      @guider = Guider.new(location: @location)
+      @guider = Guider.new
     end
 
     def set_authorised_location

--- a/app/models/guider.rb
+++ b/app/models/guider.rb
@@ -1,6 +1,4 @@
 class Guider < ApplicationRecord
-  belongs_to :location
-
   has_many :guider_assignments
   has_many :locations, through: :guider_assignments
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -24,9 +24,9 @@ class Location < ApplicationRecord # rubocop: disable Metrics/ClassLength
              class_name: 'Location'
   belongs_to :editor, class_name: 'User'
   has_many :locations, foreign_key: :booking_location_uid, primary_key: :uid
-  has_many :guiders
 
   has_many :guider_assignments
+  has_many :guiders, through: :guider_assignments
 
   validates :uid, presence: true
   validates :organisation, presence: true, inclusion: ORGANISATIONS

--- a/app/services/create_or_update_location.rb
+++ b/app/services/create_or_update_location.rb
@@ -61,7 +61,8 @@ class CreateOrUpdateLocation
     old_location = location
     build_new_version(params)
     @location.save!
-    old_location.guiders.update_all(location_id: @location.id)
+
+    old_location.guider_assignments.update_all(location_id: @location.id)
   end
 
   def previous_version_attributes

--- a/db/migrate/20170315105142_remove_location_id_from_guiders.rb
+++ b/db/migrate/20170315105142_remove_location_id_from_guiders.rb
@@ -1,0 +1,5 @@
+class RemoveLocationIdFromGuiders < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :guiders, :location_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170314101829) do
+ActiveRecord::Schema.define(version: 20170315105142) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,12 +50,10 @@ ActiveRecord::Schema.define(version: 20170314101829) do
   end
 
   create_table "guiders", force: :cascade do |t|
-    t.string   "name",        default: "", null: false
-    t.string   "email",       default: "", null: false
-    t.integer  "location_id"
-    t.datetime "created_at",               null: false
-    t.datetime "updated_at",               null: false
-    t.index ["location_id"], name: "index_guiders_on_location_id", using: :btree
+    t.string   "name",       default: "", null: false
+    t.string   "email",      default: "", null: false
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
   end
 
   create_table "locations", force: :cascade do |t|

--- a/spec/factories/guiders.rb
+++ b/spec/factories/guiders.rb
@@ -2,6 +2,5 @@ FactoryGirl.define do
   factory :guider do
     name 'Rick Sanchez'
     email 'rick@example.com'
-    location nil
   end
 end

--- a/spec/factories/location.rb
+++ b/spec/factories/location.rb
@@ -41,7 +41,7 @@ FactoryGirl.define do
       online_booking_twilio_number '+441442800110'
 
       after(:create) do |parent|
-        create(:guider, location: parent)
+        parent.guiders.create!(attributes_for(:guider))
 
         create_list(:location, 2, booking_location: parent)
       end

--- a/spec/services/update_location_spec.rb
+++ b/spec/services/update_location_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe CreateOrUpdateLocation do
 
     context 'when an existing location would be changed by the update' do
       context 'and the location has guiders assigned to it' do
-        let!(:guider) { create(:guider, location: location) }
+        let!(:guider) { location.guiders.create!(attributes_for(:guider)) }
 
         before do
           subject.update(params.merge(title: 'New title'))
@@ -48,7 +48,7 @@ RSpec.describe CreateOrUpdateLocation do
         end
 
         it 'the guiders will no longer be assigned to the old version of the location' do
-          expect(location.guiders).to be_empty
+          expect(location.reload.guiders).to be_empty
         end
       end
 


### PR DESCRIPTION
This was supplementary to 8c71e20 and completes the changes required for
guiders to exist in multiple locations.