### PR TITLE
Disable online booking for upcoming bank holidays

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -136,4 +136,8 @@ class Location < ApplicationRecord # rubocop: disable Metrics/ClassLength
   def slots
     Slot.all(cut_off_from)
   end
+
+  def can_take_online_bookings?
+    online_booking_enabled? && BANK_HOLIDAYS.exclude?(Time.zone.today)
+  end
 end

--- a/app/views/locations/index.json.jbuilder
+++ b/app/views/locations/index.json.jbuilder
@@ -10,6 +10,6 @@ json.features @locations do |location|
     json.phone location.phone.to_s
     json.hours location.hours.to_s
     json.twilio_number location.twilio_number
-    json.online_booking_enabled location.online_booking_enabled
+    json.online_booking_enabled location.can_take_online_bookings?
   end
 end

--- a/config/initializers/holidays.rb
+++ b/config/initializers/holidays.rb
@@ -1,0 +1,5 @@
+BANK_HOLIDAYS = [
+  Date.parse('14/04/2017'),
+  Date.parse('17/04/2017'),
+  Date.parse('01/05/2017')
+].freeze

--- a/spec/factories/location.rb
+++ b/spec/factories/location.rb
@@ -37,6 +37,11 @@ FactoryGirl.define do
       organisation 'nicab'
     end
 
+    trait :allows_online_booking do
+      online_booking_enabled true
+      online_booking_twilio_number '+441442800110'
+    end
+
     factory :booking_location do
       online_booking_twilio_number '+441442800110'
 

--- a/spec/features/bank_holiday_spec.rb
+++ b/spec/features/bank_holiday_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.feature 'Locations API during a bank holiday' do
+  scenario 'Requesting the locations api on a bank holiday' do
+    given_a_location_with_online_booking
+    when_we_are_on_a_bank_holiday do
+      and_i_call_the_locations_api
+      then_it_shows_the_location_as_disabled
+    end
+  end
+
+  scenario 'Requesting the locations on a non bank holiday' do
+    given_a_location_with_online_booking
+    when_we_are_not_on_a_bank_holiday do
+      and_i_call_the_locations_api
+      then_it_shows_the_location_as_enabled
+    end
+  end
+
+  def given_a_location_with_online_booking
+    create(:location, :allows_online_booking)
+  end
+
+  def when_we_are_on_a_bank_holiday(&block)
+    travel_to(Date.parse('14/04/2017'), &block)
+  end
+
+  def when_we_are_not_on_a_bank_holiday(&block)
+    travel_to(Date.parse('13/04/2017'), &block)
+  end
+
+  def and_i_call_the_locations_api
+    visit locations_path(format: :json)
+  end
+
+  def then_it_shows_the_location_as_enabled
+    json = JSON.parse(page.body)
+    status = json['features'][0]['properties']['online_booking_enabled']
+    expect(status).to be_truthy
+  end
+
+  def then_it_shows_the_location_as_disabled
+    json = JSON.parse(page.body)
+    status = json['features'][0]['properties']['online_booking_enabled']
+    expect(status).to be_falsey
+  end
+end


### PR DESCRIPTION
Largely just duplicating the previous implementation in 1e7e233612ee833a71b0dd6bc8804cf6879518b5.

Extra date for the May Day bank holiday added following discussion in this morning's standup.