### PR TITLE
Notify dependent systems when reassigning

### DIFF
--- a/app/services/create_or_update_location.rb
+++ b/app/services/create_or_update_location.rb
@@ -64,7 +64,7 @@ class CreateOrUpdateLocation
 
     old_location.guider_assignments.update_all(location_id: @location.id)
 
-    reassign_booking_location(old_location.booking_location, @location.booking_location)
+    reassign_booking_location(old_location.canonical_location, @location.booking_location)
   end
 
   def reassign_booking_location(old_booking_location, new_booking_location)

--- a/spec/services/update_location_spec.rb
+++ b/spec/services/update_location_spec.rb
@@ -36,6 +36,35 @@ RSpec.describe CreateOrUpdateLocation do
     end
 
     context 'when an existing location would be changed by the update' do
+      context 'and a booking location is being reassigned' do
+        let(:location) { create(:booking_location) }
+        let(:new_booking_location) { create(:booking_location) }
+
+        before do
+          allow(NotifyPensionGuidanceJob).to receive(:perform_later)
+          allow(NotifyPlannerJob).to receive(:perform_later)
+
+          subject.update(
+            params.merge(
+              booking_location_uid: new_booking_location.uid,
+              phone: nil,
+              hours: nil
+            )
+          )
+        end
+
+        it 'copies the guiders to the new booking location' do
+          expect(new_booking_location.guider_ids).to include(*location.guider_ids)
+        end
+
+        it 'notifies the dependent systems' do
+          expect(NotifyPlannerJob).to have_received(:perform_later).with(
+            new_booking_location.uid,
+            location.uid
+          )
+        end
+      end
+
       context 'and the location is reassigned to a different booking location' do
         let(:old_booking_location) { create(:booking_location) }
         let(:new_booking_location) { create(:booking_location) }


### PR DESCRIPTION
Previously we only triggered this behaviour in response to a child
location being reassigned to a new booking location. This change
ensures booking locations can also be reassigned.