### PR TITLE
Remove default location in search box

### DIFF
--- a/app/views/locators/index.html.erb
+++ b/app/views/locators/index.html.erb
@@ -1,5 +1,5 @@
 <div class="google-maps__panel">
-  <input id="address" type="textbox" value="Enniskillen">
+  <input id="address" type="textbox">
   <input type="button" value="Search" onclick="window.lookupAddress()">
 </div>
 <div class="google-maps__canvas"></div>


### PR DESCRIPTION
I don't see any reason why we have 'Enniskillen' as the default location in the search box

<img width="450" alt="screen shot 2017-03-28 at 12 46 54" src="https://cloud.githubusercontent.com/assets/6049076/24403408/a5812d0a-13b4-11e7-981b-5368410fa3b6.png">