### PR TITLE
Ensure slots for bank holidays are skipped

### DIFF
--- a/app/models/slot.rb
+++ b/app/models/slot.rb
@@ -25,8 +25,12 @@ class Slot
       booking_window_end = 6.weeks.from_now
 
       (grace_period..booking_window_end).reject do |date|
-        date.saturday? || date.sunday? || cut_off_from && date >= cut_off_from
+        date.saturday? || date.sunday? || cut_off_from && date >= cut_off_from || bank_holiday?(date)
       end
+    end
+
+    def bank_holiday?(date)
+      BANK_HOLIDAYS.include?(date)
     end
 
     def grace_period

--- a/config/initializers/holidays.rb
+++ b/config/initializers/holidays.rb
@@ -1,5 +1,9 @@
 BANK_HOLIDAYS = [
   Date.parse('14/04/2017'),
   Date.parse('17/04/2017'),
-  Date.parse('01/05/2017')
+  Date.parse('01/05/2017'),
+  Date.parse('29/05/2017'),
+  Date.parse('28/08/2017'),
+  Date.parse('25/12/2017'),
+  Date.parse('26/12/2017')
 ].freeze

--- a/spec/models/slot_spec.rb
+++ b/spec/models/slot_spec.rb
@@ -5,6 +5,14 @@ RSpec.describe Slot do
     travel_to(date) { described_class.all }
   end
 
+  context 'on a bank holiday' do
+    let(:date) { BANK_HOLIDAYS.first }
+
+    it 'the first slot is the following Wednesday' do
+      expect(subject.first).to have_attributes(date: '2017-04-19')
+    end
+  end
+
   context 'on Sunday' do
     let(:date) { '2016-06-05 10:00:00' }
 


### PR DESCRIPTION
This ensures folks cannot book appointments for bank holidays when
locations are closed.

Also includes all bank holidays throughout 2017.