### PR TITLE
Don't permit online bookings on or after cut-off

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -138,6 +138,14 @@ class Location < ApplicationRecord # rubocop: disable Metrics/ClassLength
   end
 
   def can_take_online_bookings?
-    online_booking_enabled? && BANK_HOLIDAYS.exclude?(Time.zone.today)
+    online_booking_enabled? && BANK_HOLIDAYS.exclude?(Time.zone.today) && operational?
+  end
+
+  def cut_off?
+    cut_off_from? && Time.zone.today >= cut_off_from
+  end
+
+  def operational?
+    !cut_off?
   end
 end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -1,6 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe Location do
+  describe '#can_take_online_bookings?' do
+    context 'when the location has passed the cut-off period' do
+      subject do
+        build_stubbed(:location, :allows_online_booking, cut_off_from: '2017-01-01')
+      end
+
+      it 'is false' do
+        expect(subject.can_take_online_bookings?).to be_falsey
+      end
+    end
+
+    context 'when the location is still operational' do
+      subject do
+        build_stubbed(:location, :allows_online_booking)
+      end
+
+      it 'is true' do
+        expect(subject.can_take_online_bookings?).to be_truthy
+      end
+    end
+  end
+
   describe '.latest_for_twilio_number' do
     let(:user) { create(:user) }
     let(:location_1_ver_1) { create(:location) }


### PR DESCRIPTION
When the affected flag is `false` in the response the button is hidden
for online bookings.