### PR TITLE
Link Location name in the Location Directory

### DIFF
--- a/app/views/admin/locations/index.html.erb
+++ b/app/views/admin/locations/index.html.erb
@@ -17,14 +17,15 @@
       <div class="row t-location" id="location-<%= location.uid %>">
         <div class="col-md-11">
           <h2 class="inline-block t-location-title">
-            <%= location.title %>
+            <%= link_to location.title, edit_admin_location_path(location.uid) %>
           </h2>
           <%= render 'admin/locations/labels', location: location %>
-          <%= render location %>
         </div>
         <div class="col-md-1">
-          <br>
-          <%= link_to 'Edit', edit_admin_location_path(location.uid), class: 'btn btn-default t-edit-button' %>
+          <br><%= link_to 'Edit', edit_admin_location_path(location.uid), class: 'btn btn-default t-edit-button' %>
+        </div>
+        <div class="col-md-12">
+          <%= render location %>
         </div>
       </div>
       <hr>


### PR DESCRIPTION
To make it easier to access the location edit page this restores the location name as a link

Minor adjustment to the position of the edit button

<img width="1192" alt="screen shot 2017-04-04 at 12 13 24" src="https://cloud.githubusercontent.com/assets/6049076/24654048/20f69c06-1930-11e7-99b9-f13f93f8cae0.png">
