### PR TITLE
Display environment labels and highlighting

### DIFF
--- a/config/initializers/govuk_admin_template.rb
+++ b/config/initializers/govuk_admin_template.rb
@@ -1,0 +1,8 @@
+GovukAdminTemplate.environment_style = Rails.env.staging? ? 'preview' : ENV['RAILS_ENV']
+GovukAdminTemplate.environment_label = Rails.env.titleize
+
+GovukAdminTemplate.configure do |c|
+  c.app_title = 'CAB Locator'
+  c.show_flash = true
+  c.show_signout = false
+end


### PR DESCRIPTION
We weren't differentiating the environments as we do with our other
applications. This can cause confusion - especially with staging and
production.