### PR TITLE
Use child location's number when provided

### DIFF
--- a/app/assets/javascripts/locator/google-maps-and-markers.js
+++ b/app/assets/javascripts/locator/google-maps-and-markers.js
@@ -153,8 +153,11 @@
         var bookingLocation = findLocationProperties(features, bookingLocationId);
         if (bookingLocation) {
           location['hours'] = bookingLocation['hours'];
-          location['phone'] = bookingLocation['phone'];
           location['booking_centre'] = bookingLocation['title'];
+
+          if (location['phone'] === '') {
+            location['phone'] = bookingLocation['phone'];
+          }
         }
       }
 


### PR DESCRIPTION
This ensures the child location's number is used instead of the booking
location's number when a value is provided.