### PR TITLE
Allow admins to supply an booking reply-to email

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -13,6 +13,7 @@ class Location < ApplicationRecord # rubocop: disable Metrics/ClassLength
     twilio_number
     online_booking_twilio_number
     online_booking_enabled
+    online_booking_reply_to
   ).freeze
   TP_CALL_CENTRE_NUMBER = '+442037333495'
   ORGANISATIONS = %w(cas cita nicab).freeze

--- a/app/policies/location_policy.rb
+++ b/app/policies/location_policy.rb
@@ -1,4 +1,12 @@
 class LocationPolicy < ApplicationPolicy
+  ADMIN_PARAMS = %i(
+    organisation
+    twilio_number
+    online_booking_twilio_number
+    online_booking_enabled
+    online_booking_reply_to
+  ).freeze
+
   class Scope < ApplicationPolicy::Scope
     def resolve
       if user.pensionwise_admin?
@@ -53,8 +61,7 @@ class LocationPolicy < ApplicationPolicy
     ]
 
     base_params += [:phone] if creating_new_record? || admin?
-    base_params += [:organisation, :twilio_number, :online_booking_twilio_number, :online_booking_enabled] if admin?
-
+    base_params += ADMIN_PARAMS if admin?
     base_params
   end
 

--- a/app/services/create_or_update_location.rb
+++ b/app/services/create_or_update_location.rb
@@ -91,7 +91,7 @@ class CreateOrUpdateLocation
   end
 
   def clean(attributes)
-    attributes.each do |key, value|
+    attributes.except(:online_booking_reply_to).each do |key, value|
       attributes[key] = nil if value.is_a?(String) && value.blank?
     end
   end

--- a/app/views/admin/locations/_form.html.erb
+++ b/app/views/admin/locations/_form.html.erb
@@ -102,6 +102,12 @@
         <%= render 'error', error_messages: location.errors[:online_booking_twilio_number] %>
         <%= f.text_field :online_booking_twilio_number, class: 'form-control t-online-booking-twilio-number' %>
       </div>
+
+      <div class="form-group <%= 'form-group--error' if f.object.errors[:online_booking_reply_to].any? %>" id="online-booking-reply-to">
+        <%= f.label :online_booking_reply_to, 'Online booking reply-to alias' %>
+        <%= render 'error', error_messages: location.errors[:online_booking_reply_to] %>
+        <%= f.text_field :online_booking_reply_to, class: 'form-control t-online-booking-reply-to' %>
+      </div>
     <% end %>
     <div class="form-group t-visibility <%= 'form-group--error' if f.object.errors[:hidden].any? %>" id="hidden">
       <%= f.label :hidden, 'Make location visible?', class: 'block' %><br/>

--- a/app/views/api/v1/booking_locations/_booking_location.json.jbuilder
+++ b/app/views/api/v1/booking_locations/_booking_location.json.jbuilder
@@ -1,6 +1,7 @@
 json.uid location.uid
 json.name location.title
 json.address location.address_line
+json.online_booking_reply_to location.online_booking_reply_to
 json.online_booking_twilio_number location.online_booking_twilio_number
 json.hidden location.hidden
 

--- a/db/migrate/20170413090950_add_booking_reply_to_email_to_locations.rb
+++ b/db/migrate/20170413090950_add_booking_reply_to_email_to_locations.rb
@@ -1,0 +1,5 @@
+class AddBookingReplyToEmailToLocations < ActiveRecord::Migration[5.0]
+  def change
+    add_column :locations, :online_booking_reply_to, :string, null: false, default: ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170324102734) do
+ActiveRecord::Schema.define(version: 20170413090950) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,6 +77,7 @@ ActiveRecord::Schema.define(version: 20170324102734) do
     t.string   "online_booking_twilio_number",             default: ""
     t.boolean  "online_booking_enabled",                   default: false
     t.date     "cut_off_from"
+    t.string   "online_booking_reply_to",                  default: "",        null: false
     t.index ["booking_location_uid"], name: "index_locations_on_booking_location_uid", using: :btree
   end
 

--- a/spec/factories/location.rb
+++ b/spec/factories/location.rb
@@ -13,6 +13,7 @@ FactoryGirl.define do
     booking_location nil
     editor { build(:user) }
     online_booking_enabled false
+    online_booking_reply_to 'dave@example.com'
 
     before(:create) do |location|
       if location.booking_location.present?

--- a/spec/policies/location_policy_spec.rb
+++ b/spec/policies/location_policy_spec.rb
@@ -119,7 +119,8 @@ RSpec.describe LocationPolicy do
             :organisation,
             :twilio_number,
             :online_booking_twilio_number,
-            :online_booking_enabled
+            :online_booking_enabled,
+            :online_booking_reply_to
           ]
         )
       end

--- a/spec/views/api/v1/booking_locations/show.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/booking_locations/show.json.jbuilder_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe 'api/v1/booking_locations/show.json.jbuilder' do
       'name' => booking_location.title,
       'address' => booking_location.address_line,
       'online_booking_twilio_number' => booking_location.online_booking_twilio_number,
+      'online_booking_reply_to' => 'dave@example.com',
       'hidden' => booking_location.hidden
     )
 
@@ -27,6 +28,7 @@ RSpec.describe 'api/v1/booking_locations/show.json.jbuilder' do
       'name' => booking_location.locations.first.title,
       'address' => booking_location.locations.first.address_line,
       'online_booking_twilio_number' => '',
+      'online_booking_reply_to' => 'dave@example.com',
       'hidden' => booking_location.locations.first.hidden,
       'locations' => [],
       'slots' => a_hash_including(


### PR DESCRIPTION
This permits admins to supply an online booking specific reply-to address.
They can supply a previously configured group mailbox alias and this will
be set for any online booking related emails via the planner application
when present in the booking locations API.