### PR TITLE
Introduce a temporary cut-off period

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -134,7 +134,7 @@ class Location < ApplicationRecord # rubocop: disable Metrics/ClassLength
   end
 
   def slots
-    Slot.all(cut_off_from)
+    Slot.all(cut_off_from, cut_off_to)
   end
 
   def can_take_online_bookings?

--- a/app/models/slot.rb
+++ b/app/models/slot.rb
@@ -10,8 +10,8 @@ class Slot
   }.freeze
 
   class << self
-    def all(cut_off_from = nil)
-      slot_dates(cut_off_from).map do |date|
+    def all(cut_off_from = nil, cut_off_to = nil)
+      slot_dates(cut_off_from, cut_off_to).map do |date|
         [
           Instance.new(date.iso8601, '0900', '1300'),
           Instance.new(date.iso8601, '1300', '1700')
@@ -21,11 +21,14 @@ class Slot
 
     private
 
-    def slot_dates(cut_off_from)
+    def slot_dates(cut_off_from, cut_off_to) # rubocop:disable Metrics/CyclomaticComplexity
       booking_window_end = 6.weeks.from_now
 
       (grace_period..booking_window_end).reject do |date|
-        date.saturday? || date.sunday? || cut_off_from && date >= cut_off_from || bank_holiday?(date)
+        date.saturday? || date.sunday? ||
+          cut_off_to && date <= cut_off_to ||
+          cut_off_from && date >= cut_off_from ||
+          bank_holiday?(date)
       end
     end
 

--- a/db/migrate/20170420121609_add_cut_off_to_to_locations.rb
+++ b/db/migrate/20170420121609_add_cut_off_to_to_locations.rb
@@ -1,0 +1,5 @@
+class AddCutOffToToLocations < ActiveRecord::Migration[5.0]
+  def change
+    add_column :locations, :cut_off_to, :date, null: true
+  end
+end

--- a/db/migrate/20170420123641_assign_cut_off_to_for_plymouth_locations.rb
+++ b/db/migrate/20170420123641_assign_cut_off_to_for_plymouth_locations.rb
@@ -1,0 +1,13 @@
+class AssignCutOffToForPlymouthLocations < ActiveRecord::Migration[5.0]
+  def up
+    Location
+      .active
+      .current
+      .where('uid = :uid or booking_location_uid = :uid', uid: 'c312229b-c96d-49d0-8362-4a3f746b3ac4')
+      .update_all(cut_off_to: '2017-05-08')
+  end
+
+  def down
+    # noop
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170413090950) do
+ActiveRecord::Schema.define(version: 20170420121609) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -78,6 +78,7 @@ ActiveRecord::Schema.define(version: 20170413090950) do
     t.boolean  "online_booking_enabled",                   default: false
     t.date     "cut_off_from"
     t.string   "online_booking_reply_to",                  default: "",        null: false
+    t.date     "cut_off_to"
     t.index ["booking_location_uid"], name: "index_locations_on_booking_location_uid", using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170420121609) do
+ActiveRecord::Schema.define(version: 20170420123641) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -118,8 +118,16 @@ RSpec.describe Location do
       context 'when a cut-off date exists' do
         let(:location) { build(:location, cut_off_from: '2016-06-23') }
 
-        it 'only returns slots after the cut-off date' do
+        it 'only returns slots before the cut-off date' do
           expect(subject.last.date).to eq('2016-06-22')
+        end
+      end
+
+      context 'when a cut-off-to date exists' do
+        let(:location) { build(:location, cut_off_to: '2016-06-23') }
+
+        it 'only returns slots after the cut-off date' do
+          expect(subject.first.date).to eq('2016-06-24')
         end
       end
     end


### PR DESCRIPTION
When we specify a `cut_off_to` date, slots will not be available for
bookings until after that date. Unlike `cut_off_from` - a hard closure of a
location - this still keeps the location open and available to take
bookings but introduces a 'breathing' period to ease processing a backlog
of bookings.