### PR TITLE
Updates to location validation

### DIFF
--- a/app/controllers/admin/locations_controller.rb
+++ b/app/controllers/admin/locations_controller.rb
@@ -36,7 +36,7 @@ module Admin
     def update
       updater = CreateOrUpdateLocation.new(location: @location, user: current_user)
       @location = updater.update(permitted_attributes(@location).to_h)
-      if @location.new_record?
+      if @location.invalid?
         @booking_locations = policy_scope(Location.booking_locations)
         render :edit
       else

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -49,7 +49,6 @@ class Location < ApplicationRecord # rubocop: disable Metrics/ClassLength
             uk_phone_number: { allow_blank: true },
             unless: :booking_location_uid?,
             if: :online_booking_enabled?
-  validates :guiders, length: { is: 0 }, if: :booking_location_uid?
   validates :hidden, inclusion: { in: [true], if: ->(l) { l.twilio_number.blank? } }
   validates :online_booking_enabled, inclusion: { in: [true, false] }
 

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -74,15 +74,6 @@ RSpec.describe Location do
   end
 
   describe '#guiders' do
-    context 'for child locations' do
-      it 'is invalid with associated guiders' do
-        location = build(:location, booking_location_uid: 'deadbeef')
-        location.guiders << build(:guider)
-
-        expect(location).to_not be_valid
-      end
-    end
-
     context 'for booking locations' do
       it 'is valid with associated guiders' do
         location = build(:booking_location)


### PR DESCRIPTION
* don't assert lack of guiders when a child location
* stop swallowing validation errors on the location edit page