### PR TITLE
Allow bookings during bank holidays

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -137,7 +137,7 @@ class Location < ApplicationRecord # rubocop: disable Metrics/ClassLength
   end
 
   def can_take_online_bookings?
-    online_booking_enabled? && BANK_HOLIDAYS.exclude?(Time.zone.today) && operational?
+    online_booking_enabled? && operational?
   end
 
   def cut_off?

--- a/spec/features/bank_holiday_spec.rb
+++ b/spec/features/bank_holiday_spec.rb
@@ -5,14 +5,6 @@ RSpec.feature 'Locations API during a bank holiday' do
     given_a_location_with_online_booking
     when_we_are_on_a_bank_holiday do
       and_i_call_the_locations_api
-      then_it_shows_the_location_as_disabled
-    end
-  end
-
-  scenario 'Requesting the locations on a non bank holiday' do
-    given_a_location_with_online_booking
-    when_we_are_not_on_a_bank_holiday do
-      and_i_call_the_locations_api
       then_it_shows_the_location_as_enabled
     end
   end
@@ -25,10 +17,6 @@ RSpec.feature 'Locations API during a bank holiday' do
     travel_to(Date.parse('14/04/2017'), &block)
   end
 
-  def when_we_are_not_on_a_bank_holiday(&block)
-    travel_to(Date.parse('13/04/2017'), &block)
-  end
-
   def and_i_call_the_locations_api
     visit locations_path(format: :json)
   end
@@ -37,11 +25,5 @@ RSpec.feature 'Locations API during a bank holiday' do
     json = JSON.parse(page.body)
     status = json['features'][0]['properties']['online_booking_enabled']
     expect(status).to be_truthy
-  end
-
-  def then_it_shows_the_location_as_disabled
-    json = JSON.parse(page.body)
-    status = json['features'][0]['properties']['online_booking_enabled']
-    expect(status).to be_falsey
   end
 end


### PR DESCRIPTION
Before this change we hid the online booking button. We now allow
customers to enter the bookings process regardless whether the current
day is a public holiday. This makes sense as the slots and cut-off
period logic will not allow a customer to book an appointment *for* a
public holiday, yet nothing ought to stop a customer from placing a
booking during this period.