### PR TITLE
Correct booking location query

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -71,7 +71,7 @@ class Location < ApplicationRecord # rubocop: disable Metrics/ClassLength
     end
 
     def booking_locations
-      current.active.where(booking_location_uid: nil)
+      current.active.where(booking_location_uid: [nil, ''])
     end
 
     def externally_visible(include_hidden_locations:)

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -1,6 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe Location do
+  describe '.booking_locations' do
+    before do
+      @booking_locations = [
+        create(:location, booking_location_uid: nil),
+        create(:location, booking_location_uid: '')
+      ]
+
+      @location = create(:location, booking_location_uid: SecureRandom.uuid)
+    end
+
+    it 'lists the correct locations' do
+      expect(described_class.booking_locations).to eq(@booking_locations)
+    end
+  end
+
   describe '#can_take_online_bookings?' do
     context 'when the location has passed the cut-off period' do
       subject do


### PR DESCRIPTION
Unfortunately it seems booking location IDs are updated to empty strings
now, not `nil` as they were before. This means the logic to determine
whether a location is a booking location was slightly off. We ought to
accomodate both `nil` and empty strings when performing this check.