### PR TITLE
If present redirect to a location’s phone number over that of the booking location

### DIFF
--- a/app/models/twilio_redirection.rb
+++ b/app/models/twilio_redirection.rb
@@ -5,12 +5,12 @@ module TwilioRedirection
 
   def self.lookup_current_location(twilio_number)
     location = ::Location.current.find_by(twilio_number: twilio_number)
-    location ? TwilioRedirection::Location.new(location.canonical_location) : nil
+    location ? TwilioRedirection::Location.new(location) : nil
   end
 
   def self.lookup_old_location(twilio_number)
     location = ::Location.order('created_at DESC').find_by(twilio_number: twilio_number)&.current_version
-    location ? TwilioRedirection::Location.new(location.canonical_location) : nil
+    location ? TwilioRedirection::Location.new(location) : nil
   end
 
   def self.lookup_call_centre(twilio_number)

--- a/app/models/twilio_redirection/location.rb
+++ b/app/models/twilio_redirection/location.rb
@@ -7,15 +7,19 @@ module TwilioRedirection
     end
 
     def phone
-      return ::Location::TP_CALL_CENTRE_NUMBER if redirect_to_call_center?
-
-      recipient_location.phone
+      if redirect_to_call_center?
+        ::Location::TP_CALL_CENTRE_NUMBER
+      else
+        recipient_location.phone
+      end
     end
 
     def phone_options
-      return {} if recipient_location.extension.blank?
-
-      { sendDigits: recipient_location.extension }
+      if recipient_location.extension.blank?
+        {}
+      else
+        { sendDigits: recipient_location.extension }
+      end
     end
 
     private

--- a/app/models/twilio_redirection/location.rb
+++ b/app/models/twilio_redirection/location.rb
@@ -7,15 +7,25 @@ module TwilioRedirection
     end
 
     def phone
-      return ::Location::TP_CALL_CENTRE_NUMBER if @location.hidden?
+      return ::Location::TP_CALL_CENTRE_NUMBER if redirect_to_call_center?
 
-      @location.phone
+      recipient_location.phone
     end
 
     def phone_options
-      return {} if @location.extension.blank?
+      return {} if recipient_location.extension.blank?
 
-      { sendDigits: @location.extension }
+      { sendDigits: recipient_location.extension }
+    end
+
+    private
+
+    def redirect_to_call_center?
+      [@location.booking_location, @location].compact.all?(&:hidden?)
+    end
+
+    def recipient_location
+      @location.phone.present? ? @location : @location.booking_location
     end
   end
 end

--- a/spec/features/twilio_number_lookup_spec.rb
+++ b/spec/features/twilio_number_lookup_spec.rb
@@ -8,6 +8,20 @@ RSpec.describe 'Twilio number lookup', type: :request do
       then_xml_containing_the_location_number_is_returned
     end
 
+    context 'and the location has booking location' do
+      it 'will forward to the location phones if a number exists' do
+        given_a_location_exists_with_a_booking_location_and_own_phone
+        when_twilio_requests_a_forwarding_number
+        then_xml_containing_the_location_number_is_returned
+      end
+
+      it 'will forward to the booking location phones if no number of its own exists' do
+        given_a_location_exists_with_a_booking_location
+        when_twilio_requests_a_forwarding_number
+        then_xml_containing_the_booking_location_number_is_returned
+      end
+    end
+
     it 'will include the locations extension is one exists' do
       given_a_location_exists_that_requires_an_extension
       when_twilio_requests_a_forwarding_number
@@ -68,6 +82,15 @@ RSpec.describe 'Twilio number lookup', type: :request do
   def given_a_location_exists_with_a_booking_location
     @booking_location = create(:location)
     @redirection = create(:location, phone: nil, booking_location: @booking_location)
+  end
+
+  def given_a_location_exists_with_a_booking_location_and_own_phone
+    @booking_location = create(:location)
+    @redirection = create(:location)
+
+    # Associate after creation, as factory clears the phone (and hours)
+    # on creation if a booking location is present.
+    @redirection.update_attribute(:booking_location, @booking_location)
   end
 
   def given_a_hidden_location_exists_with_a_booking_location

--- a/spec/models/twilio_redirect_spec.rb
+++ b/spec/models/twilio_redirect_spec.rb
@@ -12,6 +12,26 @@ RSpec.describe TwilioRedirection do
         it 'redirects to the locations phone number' do
           expect(described_class.for(twilio_number).phone).to eq(location.phone)
         end
+
+        context 'and it has a booking location' do
+          let(:booking_location) { create(:location) }
+
+          before do
+            location.update_attribute(:booking_location, booking_location)
+          end
+
+          it 'still redirects to the locations phone number' do
+            expect(described_class.for(twilio_number).phone).to eq(location.phone)
+          end
+
+          context 'and the location has no phone number' do
+            before { location.update_attribute(:phone, nil) }
+
+            it 'redirects to the booking locations phone number' do
+              expect(described_class.for(twilio_number).phone).to eq(booking_location.phone)
+            end
+          end
+        end
       end
 
       context 'and the location is hidden' do


### PR DESCRIPTION
A requested change in the redirection behaviour.

Currently when a call comes in to a location's Twilio number and that location has a booking location, we redirect the call to that booking location's number.

The amended behaviour now checks the location for a number of its own and if present uses that over that of the booking location.