### PR TITLE
Update manner in which we render information for map markers

### DIFF
--- a/app/assets/javascripts/locator/google-maps-and-markers.js
+++ b/app/assets/javascripts/locator/google-maps-and-markers.js
@@ -93,17 +93,27 @@
       '<p>', l['address'].replace(/(?:\r\n|\r|\n)/g, '<br />'), '</p>'
     ];
 
-    if (l['booking_centre'] && l['booking_centre'] !== l['title']) {
-      elements.push(
-        '<p><b>Booking Centre Details</b></p>',
-        '<p>', l['booking_centre'] + ' Citizens Advice', '</p>'
-      );
-    }
+    if (l['booking_location'] && l['phone'].length === 0) {
+      var bl = l['booking_location'];
 
-    elements.push(
-      '<p>', l['hours'].replace(/(?:\r\n|\r|\n)/g, '<br />'), '</p>',
-      l['phone']
-    );
+      elements.push(
+        '<p>', l['phone'], '</p>',
+        '<p><b>Booking Centre Details</b></p>',
+        '<p>', bl['title'] + ' Citizens Advice', '</p>',
+        '<p>', bl['hours'].replace(/(?:\r\n|\r|\n)/g, '<br />'), '</p>',
+        bl['phone']
+      );
+    } else {
+      // If this is a child location with a phone number,
+      // opening hours might not be present.
+      if (l['hours'].length > 0) {
+        elements.push(
+          '<p>', l['hours'].replace(/(?:\r\n|\r|\n)/g, '<br />'), '</p>'
+        );
+      }
+
+      elements.push(l['phone']);
+    }
 
     return elements.join('\n');
   }
@@ -152,12 +162,11 @@
       if (bookingLocationId && bookingLocationId !== '') {
         var bookingLocation = findLocationProperties(features, bookingLocationId);
         if (bookingLocation) {
-          location['hours'] = bookingLocation['hours'];
-          location['booking_centre'] = bookingLocation['title'];
-
-          if (location['phone'] === '') {
-            location['phone'] = bookingLocation['phone'];
-          }
+          location['booking_location'] = {
+            hours: bookingLocation['hours'],
+            title: bookingLocation['title'],
+            phone: bookingLocation['phone']
+          };
         }
       }
 


### PR DESCRIPTION

Since some child locations are now taking bookings via their own direct phone number, if they have one populated we display it on the marker it in the same way that we would if it were a booking location.

**A booking location**

<img width="255" alt="screen shot 2017-06-21 at 11 15 37" src="https://user-images.githubusercontent.com/9943/27380043-9fccb6d2-5675-11e7-83f1-6e238d5d055d.png">

**A child location**

<img width="271" alt="screen shot 2017-06-21 at 11 15 48" src="https://user-images.githubusercontent.com/9943/27380050-a31db638-5675-11e7-8e3c-dd858d22f095.png">

**A child location with their own number**

<img width="278" alt="screen shot 2017-06-21 at 11 15 18" src="https://user-images.githubusercontent.com/9943/27380038-9b7a0076-5675-11e7-881f-8f4a9334f12c.png">

