### PR TITLE
Return the canonical online booking number

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -142,4 +142,14 @@ class Location < ApplicationRecord # rubocop: disable Metrics/ClassLength
   def operational?
     !cut_off?
   end
+
+  def canonical_online_booking_twilio_number
+    if online_booking_twilio_number.present?
+      online_booking_twilio_number
+    elsif booking_location_uid?
+      booking_location.online_booking_twilio_number
+    else
+      ''
+    end
+  end
 end

--- a/app/views/api/v1/booking_locations/_booking_location.json.jbuilder
+++ b/app/views/api/v1/booking_locations/_booking_location.json.jbuilder
@@ -2,7 +2,7 @@ json.uid location.uid
 json.name location.title
 json.address location.address_line
 json.online_booking_reply_to location.online_booking_reply_to
-json.online_booking_twilio_number location.online_booking_twilio_number
+json.online_booking_twilio_number location.canonical_online_booking_twilio_number
 json.hidden location.hidden
 
 json.locations location.locations.current do |child|

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -165,6 +165,35 @@ RSpec.describe Location do
     expect(location).to be_valid
   end
 
+  describe '#canonical_online_booking_twilio_number' do
+    let(:location) do
+      build :location do |location|
+        location.booking_location = booking_location
+        location.online_booking_enabled = true
+        location.online_booking_twilio_number = '+4480012345678'
+      end
+    end
+    let(:booking_location) { create(:location, online_booking_twilio_number: '+44800321321') }
+
+    context 'when the child has an #online_booking_twilio_number' do
+      it 'returns the child number' do
+        expect(location.canonical_online_booking_twilio_number).to eq(
+          location.online_booking_twilio_number
+        )
+      end
+    end
+
+    context 'when the child does not have an #online_booking_twilio_number' do
+      it 'returns the parent number' do
+        location.online_booking_twilio_number = ''
+
+        expect(booking_location.canonical_online_booking_twilio_number).to eq(
+          booking_location.online_booking_twilio_number
+        )
+      end
+    end
+  end
+
   describe '#online_booking_twilio_number' do
     let(:location) do
       build :location do |location|

--- a/spec/views/api/v1/booking_locations/show.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/booking_locations/show.json.jbuilder_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'api/v1/booking_locations/show.json.jbuilder' do
       'uid' => booking_location.locations.first.uid,
       'name' => booking_location.locations.first.title,
       'address' => booking_location.locations.first.address_line,
-      'online_booking_twilio_number' => '',
+      'online_booking_twilio_number' => booking_location.online_booking_twilio_number,
       'online_booking_reply_to' => 'dave@example.com',
       'hidden' => booking_location.locations.first.hidden,
       'locations' => []


### PR DESCRIPTION
Introduces logic to resolve a canonical online booking twilio number.
When the child's number is present this is used to override the
parent's.