### PR TITLE
Google maps api key

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+GOOGLE_MAP_API_KEY=fake-google-map-api-key

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,9 @@ branches:
   - "/^prototypes\\/.*$/"
 addons:
   postgresql: 9.4
-before_script:
+before_install:
 - gem update --system
-- gem update bundler
-- "./bin/rake db:setup RAILS_ENV=test"
+- gem install bundler -v=1.16.2
+before_script:
 - npm install
+- bundle exec rake db:setup RAILS_ENV=test

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Manage [Pension Wise] locations.
 * [Bundler]
 * [Git]
 * [PostgreSQL]
-* [Ruby 2.3.1][Ruby]
+* [Ruby 2.5.1][Ruby]
 * [Signon]
 
 

--- a/app/helpers/google_maps_api_helper.rb
+++ b/app/helpers/google_maps_api_helper.rb
@@ -1,0 +1,7 @@
+module GoogleMapsApiHelper
+  def google_maps_api_source_url
+    api_key = ENV.fetch('GOOGLE_MAP_API_KEY')
+
+    "https://maps.googleapis.com/maps/api/js?key=#{api_key}&region=GB&libraries=geometry"
+  end
+end

--- a/app/views/locators/index.html.erb
+++ b/app/views/locators/index.html.erb
@@ -6,5 +6,5 @@
 
 
 <% content_for :body_end do %>
-  <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?region=GB&libraries=geometry"></script>
+  <%= javascript_include_tag google_maps_api_source_url %>
 <% end %>

--- a/spec/helpers/google_maps_api_helper_spec.rb
+++ b/spec/helpers/google_maps_api_helper_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe GoogleMapsApiHelper, '#google_maps_api_source_url' do
+  it 'returns a URL which includes the API key' do
+    allow(ENV).to receive(:fetch).with('GOOGLE_MAP_API_KEY').and_return('fake-key')
+
+    expect(google_maps_api_source_url).to eq(
+      'https://maps.googleapis.com/maps/api/js?key=fake-key&region=GB&libraries=geometry'
+    )
+  end
+end


### PR DESCRIPTION
This is a fix in response to a P3 raised by Abdul.

-----

Description: We have noticed that the locator maps here is showing a 'for development purposes' error. This interface is also used by TP agent so slightly concerned that it may affect their role. There's a small chance it might be because the google maps account may not have been paid. However, the issue may be unrelated and the colleagues familiar with the payment systems are currently not at work

Steps taken: This seems to happen regardless of browser / user.

Action required: Investigate potential issue with locator maps