### PR TITLE
Allow locations to be realtime enabled

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -14,6 +14,7 @@ class Location < ApplicationRecord # rubocop: disable Metrics/ClassLength
     online_booking_twilio_number
     online_booking_enabled
     online_booking_reply_to
+    realtime
   ).freeze
   TP_CALL_CENTRE_NUMBER = '+442037333495'
   ORGANISATIONS = %w(cas cita nicab).freeze
@@ -50,6 +51,7 @@ class Location < ApplicationRecord # rubocop: disable Metrics/ClassLength
             if: :online_booking_enabled?
   validates :hidden, inclusion: { in: [true], if: ->(l) { l.twilio_number.blank? } }
   validates :online_booking_enabled, inclusion: { in: [true, false] }
+  validates :realtime, inclusion: { in: [true, false] }
 
   default_scope -> { order(:title) }
   scope :current, -> { where(state: 'current') }

--- a/app/policies/location_policy.rb
+++ b/app/policies/location_policy.rb
@@ -5,6 +5,7 @@ class LocationPolicy < ApplicationPolicy
     online_booking_twilio_number
     online_booking_enabled
     online_booking_reply_to
+    realtime
   ).freeze
 
   class Scope < ApplicationPolicy::Scope

--- a/app/views/admin/locations/_form.html.erb
+++ b/app/views/admin/locations/_form.html.erb
@@ -128,6 +128,14 @@
         <%= f.radio_button :online_booking_enabled, false, class: 'l-location-status__checkbox', id: "location_online_booking_enabled_false_#{location.id}" %>
         <%= f.label "online_booking_enabled_false_#{location.id}", 'Disabled', class: 'l-location-status__label' %>
       </div>
+      <div class="form-group <%= 'form-group--error' if f.object.errors[:realtime].any? %>" id="realtime">
+        <%= f.label :realtime, 'Realtime booking?', class: 'block' %><br/>
+        <%= render 'error', error_messages: location.errors[:realtime] %>
+        <%= f.radio_button :realtime, true, class: 'l-location-status__checkbox', id: "location_realtime_true_#{location.id}" %>
+        <%= f.label "realtime_true_#{location.id}", 'Enabled', class: 'l-location-status__label' %>
+        <%= f.radio_button :realtime, false, class: 'l-location-status__checkbox', id: "location_realtime_false_#{location.id}" %>
+        <%= f.label "realtime_false_#{location.id}", 'Disabled', class: 'l-location-status__label' %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/api/v1/booking_locations/_booking_location.json.jbuilder
+++ b/app/views/api/v1/booking_locations/_booking_location.json.jbuilder
@@ -5,6 +5,7 @@ json.online_booking_reply_to location.online_booking_reply_to
 json.online_booking_twilio_number location.canonical_online_booking_twilio_number
 json.online_booking_weekends location.online_booking_weekends
 json.hidden location.hidden
+json.realtime location.realtime
 
 json.locations location.locations.current do |child|
   json.partial! 'booking_location', location: child

--- a/app/views/locations/index.json.jbuilder
+++ b/app/views/locations/index.json.jbuilder
@@ -11,5 +11,6 @@ json.features @locations do |location|
     json.hours location.hours.to_s
     json.twilio_number location.twilio_number
     json.online_booking_enabled location.can_take_online_bookings?
+    json.realtime location.realtime
   end
 end

--- a/db/migrate/20181031101324_add_realtime_to_locations.rb
+++ b/db/migrate/20181031101324_add_realtime_to_locations.rb
@@ -1,0 +1,5 @@
+class AddRealtimeToLocations < ActiveRecord::Migration[5.1]
+  def change
+    add_column :locations, :realtime, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180530090652) do
+ActiveRecord::Schema.define(version: 20181031101324) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,6 +81,7 @@ ActiveRecord::Schema.define(version: 20180530090652) do
     t.string "online_booking_reply_to", default: "", null: false
     t.date "cut_off_to"
     t.boolean "online_booking_weekends", default: false, null: false
+    t.boolean "realtime", default: false, null: false
     t.index ["booking_location_uid"], name: "index_locations_on_booking_location_uid"
   end
 

--- a/spec/factories/location.rb
+++ b/spec/factories/location.rb
@@ -12,6 +12,7 @@ FactoryBot.define do
     hours 'MON-FRI 9am-5pm'
     booking_location nil
     editor { build(:user) }
+    realtime false
     online_booking_enabled false
     online_booking_reply_to 'dave@example.com'
 
@@ -42,6 +43,7 @@ FactoryBot.define do
       online_booking_enabled true
       online_booking_weekends true
       online_booking_twilio_number '+441442800110'
+      realtime true
     end
 
     factory :booking_location do

--- a/spec/policies/location_policy_spec.rb
+++ b/spec/policies/location_policy_spec.rb
@@ -120,7 +120,8 @@ RSpec.describe LocationPolicy do
             :twilio_number,
             :online_booking_twilio_number,
             :online_booking_enabled,
-            :online_booking_reply_to
+            :online_booking_reply_to,
+            :realtime
           ]
         )
       end

--- a/spec/views/api/v1/booking_locations/show.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/booking_locations/show.json.jbuilder_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe 'api/v1/booking_locations/show.json.jbuilder' do
       'online_booking_twilio_number' => booking_location.online_booking_twilio_number,
       'online_booking_reply_to' => 'dave@example.com',
       'online_booking_weekends' => true,
-      'hidden' => booking_location.hidden
+      'hidden' => booking_location.hidden,
+      'realtime' => false
     )
 
     expect(subject['locations'].first).to include(
@@ -32,7 +33,8 @@ RSpec.describe 'api/v1/booking_locations/show.json.jbuilder' do
       'online_booking_reply_to' => 'dave@example.com',
       'online_booking_weekends' => true,
       'hidden' => booking_location.locations.first.hidden,
-      'locations' => []
+      'locations' => [],
+      'realtime' => true
     )
 
     expect(subject['guiders'].first).to eq(

--- a/spec/views/locations/index.json.jbuilder_spec.rb
+++ b/spec/views/locations/index.json.jbuilder_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe 'locations/index' do
             'phone' => location.phone,
             'hours' => 'MON-FRI 9am-5pm',
             'twilio_number' => location.twilio_number,
-            'online_booking_enabled' => false
+            'online_booking_enabled' => false,
+            'realtime' => false
           }
         }
       ]


### PR DESCRIPTION
Adds a flag that persists through the various location APIs to signify
the specific location is realtime enabled.