### PR TITLE
Audit changes to `realtime`

### DIFF
--- a/app/models/edited_location.rb
+++ b/app/models/edited_location.rb
@@ -10,7 +10,8 @@ class EditedLocation
     twilio_number: EditedField,
     booking_location: EditedField::BookingLocationField,
     online_booking_twilio_number: EditedField,
-    online_booking_enabled: EditedField
+    online_booking_enabled: EditedField,
+    realtime: EditedField
   }.freeze
 
   class << self


### PR DESCRIPTION
This wasn't configured before so audits for changes to the realtime
booking status of a location were not tracked.