### PR TITLE
Allow guider visibility to be toggled

### DIFF
--- a/app/controllers/admin/guiders_controller.rb
+++ b/app/controllers/admin/guiders_controller.rb
@@ -4,13 +4,20 @@ module Admin
     before_action :set_guider, except: :create
 
     def index
-      @guiders = @location.guiders
     end
 
     def create
       @location.guiders.create!(guider_params)
 
       redirect_to admin_location_guiders_path(@location.uid)
+    end
+
+    def update
+      @guider = @location.guiders.find(params[:id])
+      @guider.toggle_hidden!
+
+      redirect_back fallback_location: admin_location_guiders_path(@location.uid),
+                    notice: 'The guider was hidden/unhidden'
     end
 
     private

--- a/app/helpers/guiders_helper.rb
+++ b/app/helpers/guiders_helper.rb
@@ -1,0 +1,12 @@
+module GuidersHelper
+  def toggle_guider_button(guider)
+    title = guider.hidden? ? 'Unhide' : 'Hide'
+
+    button_to(
+      title,
+      admin_location_guider_path(location_id: @location.uid, id: guider.id),
+      method: :patch,
+      class: 'btn btn-danger t-toggle'
+    )
+  end
+end

--- a/app/models/guider.rb
+++ b/app/models/guider.rb
@@ -1,4 +1,20 @@
 class Guider < ApplicationRecord
+  HIDDEN = '[HIDDEN] '.freeze
+
   has_many :guider_assignments
   has_many :locations, through: :guider_assignments
+
+  def hidden?
+    name.to_s.starts_with?(HIDDEN)
+  end
+
+  def toggle_hidden!
+    self.name = if hidden?
+                  name.sub(HIDDEN, '')
+                else
+                  "#{HIDDEN}#{name}"
+                end
+
+    save!
+  end
 end

--- a/app/views/admin/guiders/index.html.erb
+++ b/app/views/admin/guiders/index.html.erb
@@ -33,13 +33,15 @@
         <tr class="table-header">
           <th>Name</th>
           <th>Email</th>
+          <th></th>
         </tr>
       </thead>
       <tbody>
-        <% @location.guiders.each do |guider| %>
+        <% @location.guiders.order(:name).each do |guider| %>
           <tr class="t-guider">
             <td class="t-guider-name"><%= guider.name %></td>
             <td class="t-guider-email"><%= guider.email %></td>
+            <td><%= toggle_guider_button(guider) %></td>
           </tr>
         <% end %>
       </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
     resources :locations, except: %i(destroy show) do
       get 'online_booking', on: :member
 
-      resources :guiders, only: %i(index create)
+      resources :guiders, only: %i(index create update)
     end
 
     resources :edited_locations, only: [:index]

--- a/features/admin_location.feature
+++ b/features/admin_location.feature
@@ -71,3 +71,7 @@ Feature: Admin - Location Directory
     When I visit the "London" location
     And I add a guider
     Then the guider is added
+    When I hide the guider
+    Then the guider is hidden
+    When I unhide the guider
+    Then the guider is visible

--- a/features/pages/admin_guider_page.rb
+++ b/features/pages/admin_guider_page.rb
@@ -8,5 +8,6 @@ class AdminGuiderPage < SitePrism::Page
   sections :guiders, '.t-guider' do
     element :name, '.t-guider-name'
     element :email, '.t-guider-email'
+    element :toggle, '.t-toggle'
   end
 end

--- a/features/step_definitions/admin/location_steps.rb
+++ b/features/step_definitions/admin/location_steps.rb
@@ -72,13 +72,28 @@ When(/^I add a guider$/) do
 end
 
 Then(/^the guider is added$/) do
-  AdminGuiderPage.new.tap do |guider_page|
-    expect(guider_page).to be_displayed
-    expect(guider_page).to have_guiders(count: 1)
+  @guider_page = AdminGuiderPage.new
 
-    expect(guider_page.guiders.first.name.text).to eq('Ben Lovell')
-    expect(guider_page.guiders.first.email.text).to eq('ben@example.com')
-  end
+  expect(@guider_page).to be_displayed
+  expect(@guider_page).to have_guiders(count: 1)
+  expect(@guider_page.guiders.first.name.text).to eq('Ben Lovell')
+  expect(@guider_page.guiders.first.email.text).to eq('ben@example.com')
+end
+
+When('I hide the guider') do
+  @guider_page.guiders.first.toggle.click
+end
+
+Then('the guider is hidden') do
+  expect(@guider_page.guiders.first.name).to have_text('HIDDEN')
+end
+
+When('I unhide the guider') do
+  @guider_page.guiders.first.toggle.click
+end
+
+Then('the guider is visible') do
+  expect(@guider_page.guiders.first.name).to have_no_text('HIDDEN')
 end
 
 module LocationTestHelper


### PR DESCRIPTION
This isn't idle but it was the pattern that proliferated across the
platform. Once we have all locations enrolled in the realtime we can
come back and tidy up how guider visibility works.