### PR TITLE
Ensure organisations can be assigned

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'sinatra', require: false
 group :development, :test do
   gem 'dotenv-rails'
   gem 'pry-byebug'
+  gem 'launchy'
   gem 'rspec-rails'
   gem 'scss-lint'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,8 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     jwt (2.1.0)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     loofah (2.3.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -357,6 +359,7 @@ DEPENDENCIES
   govuk_admin_template
   jbuilder
   jquery-rails
+  launchy
   oj
   pg
   phantomjs
@@ -385,4 +388,4 @@ RUBY VERSION
    ruby 2.6.2p47
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/app/services/create_or_update_location.rb
+++ b/app/services/create_or_update_location.rb
@@ -28,7 +28,7 @@ class CreateOrUpdateLocation
 
     Location.transaction do
       begin
-        location.update_attributes!(state: 'old')
+        location.update_attribute(:state, 'old')
         create_new_version(params)
       rescue ActiveRecord::RecordInvalid
         raise ActiveRecord::Rollback

--- a/features/admin_location.feature
+++ b/features/admin_location.feature
@@ -3,6 +3,14 @@ Feature: Admin - Location Directory
   I want to be able to view and edit my CAB locations
   So that I can manage the location setup
 
+  Scenario: Assigning an organisation to an existing location
+    Given I am a pensionwise admin
+    And a location exists called "Apples"
+    And the "Apples" location has no organisation
+    When I visit the "Apples" location
+    And I select the locations "organisation" field to "nicab"
+    Then the "Apples" location has a new version where "organisation" has been set to "nicab"
+
   Scenario: Viewing a locations details for my organisation as a project manager
     Given a location exists for my organisation
     When I visit the locations admin page

--- a/features/pages/admin_location_page.rb
+++ b/features/pages/admin_location_page.rb
@@ -5,6 +5,7 @@ class AdminLocationPage < SitePrism::Page
   element :booking_hours, '.t-booking-hours'
   element :make_location_visible, '.t-visibility'
   element :booking_location, '.t-booking-location'
+  element :organisation, '.t-organisation'
 
   element :address_line_1, '.t-address-line-1'
   element :address_line_2, '.t-address-line-2'

--- a/features/step_definitions/admin/location_steps.rb
+++ b/features/step_definitions/admin/location_steps.rb
@@ -19,6 +19,12 @@ Then(/^I can see the locations details$/) do
   expect(@page).to have_hidden_true
 end
 
+Given(/^the "([^"]*)" location has no organisation$/) do |location_title|
+  @location = Location.find_by(title: location_title)
+  # avoid validation to get into the needed state
+  @location.update_attribute(:organisation, '')
+end
+
 Given(/^a location exist for another organisations$/) do
   create(:user, :project_manager, :nicab)
   @location = create(:location, :cas)

--- a/features/support/javascript_driver.rb
+++ b/features/support/javascript_driver.rb
@@ -11,5 +11,5 @@ else
   end
 
   Capybara.javascript_driver = :poltergeist
-  Capybara.default_max_wait_time = 20
+  Capybara.default_max_wait_time = 5
 end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -316,4 +316,12 @@ RSpec.describe Location do
       end
     end
   end
+
+  describe 'Organisation validations' do
+    it 'permits allowed organisations' do
+      expect(build(:location, organisation: '')).to be_invalid
+
+      expect(build(:location, :cas)).to be_valid
+    end
+  end
 end


### PR DESCRIPTION
Locations without an organisation assigned from creation cannot 
subsequently be assigned an organisation. This was due to an issue with the
dodgy versioning scheme bailing out of a transaction and swallowing the
error.