### PR TITLE
Sign google maps requests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.13.1)
       faraday (>= 0.7.4, < 1.0)
-    ffi (1.10.0)
+    ffi (1.15.5)
     foreman (0.85.0)
       thor (~> 0.19.1)
     gaffe (1.2.0)

--- a/app/helpers/google_maps_api_helper.rb
+++ b/app/helpers/google_maps_api_helper.rb
@@ -1,7 +1,8 @@
 module GoogleMapsApiHelper
   def google_maps_api_source_url
-    api_key = ENV.fetch('GOOGLE_MAP_API_KEY')
+    api_key   = ENV.fetch('GOOGLE_MAP_API_KEY')
+    signature = ENV.fetch('GOOGLE_MAP_API_SIGNATURE')
 
-    "https://maps.googleapis.com/maps/api/js?key=#{api_key}&region=GB&libraries=geometry"
+    "https://maps.googleapis.com/maps/api/js?key=#{api_key}&region=GB&libraries=geometry&signature=#{signature}"
   end
 end

--- a/spec/helpers/google_maps_api_helper_spec.rb
+++ b/spec/helpers/google_maps_api_helper_spec.rb
@@ -3,9 +3,10 @@ require 'rails_helper'
 RSpec.describe GoogleMapsApiHelper, '#google_maps_api_source_url' do
   it 'returns a URL which includes the API key' do
     allow(ENV).to receive(:fetch).with('GOOGLE_MAP_API_KEY').and_return('fake-key')
+    allow(ENV).to receive(:fetch).with('GOOGLE_MAP_API_SIGNATURE').and_return('fake-signature')
 
     expect(google_maps_api_source_url).to eq(
-      'https://maps.googleapis.com/maps/api/js?key=fake-key&region=GB&libraries=geometry'
+      'https://maps.googleapis.com/maps/api/js?key=fake-key&region=GB&libraries=geometry&signature=fake-signature'
     )
   end
 end


### PR DESCRIPTION
Ensures we sign request URLs with the given signature so we can better control
access to this API, especially since the key is shared.