### PR TITLE
Scope locations for CITA E & W project managers

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,4 +10,8 @@ class User < ApplicationRecord
   def project_manager?
     permissions.include?('project_manager')
   end
+
+  def cita_england_and_wales?
+    organisation_slug == 'cita'.freeze
+  end
 end

--- a/app/policies/location_policy.rb
+++ b/app/policies/location_policy.rb
@@ -13,7 +13,11 @@ class LocationPolicy < ApplicationPolicy
       if user.pensionwise_admin?
         scope.all
       elsif user.project_manager?
-        scope.where(organisation: user.organisation_slug)
+        if user.cita_england_and_wales?
+          scope.where(organisation: %w(cita_e cita_w nicab))
+        else
+          scope.where(organisation: user.organisation_slug)
+        end
       else
         scope.none
       end

--- a/spec/factories/location.rb
+++ b/spec/factories/location.rb
@@ -32,6 +32,10 @@ FactoryBot.define do
       organisation { 'cita_e' }
     end
 
+    trait :cita_w do
+      organisation { 'cita_w' }
+    end
+
     trait :one_line_address do
       address { build(:one_line_address) }
     end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -17,6 +17,10 @@ FactoryBot.define do
       organisation_slug { 'nicab' }
     end
 
+    trait :cita_e_w do
+      organisation_slug { 'cita' }
+    end
+
     trait :pensionwise_admin do
       permissions { %w(signin pensionwise_admin) }
     end

--- a/spec/policies/location_policy_spec.rb
+++ b/spec/policies/location_policy_spec.rb
@@ -189,6 +189,17 @@ RSpec.describe LocationPolicy::Scope do
     it 'users can not see locations for alternative organisations' do
       expect(subject.resolve).not_to include(nicab_location)
     end
+
+    context 'when the user is a CITA E & W project manager' do
+      let(:user) { create(:user, :cita_e_w, :project_manager) }
+
+      it 'can see locations for CITA E & W and NI' do
+        cita_england = create(:location, :cita_e)
+        cita_wales   = create(:location, :cita_w)
+
+        expect(subject.resolve).to include(cita_england, cita_wales, nicab_location)
+      end
+    end
   end
 
   context 'when user does not have any specified permissions/roles' do


### PR DESCRIPTION
This allows them to see locations for CITA E & W and NI when they're assigned the `project_manager` permission.