### PR TITLE
Ensure permission scopes are correct

### DIFF
--- a/app/policies/location_policy.rb
+++ b/app/policies/location_policy.rb
@@ -1,4 +1,6 @@
 class LocationPolicy < ApplicationPolicy
+  CITA_ENGLAND_AND_WALES_ORGANISATIONS = %w(cita_e cita_w nicab).freeze
+
   ADMIN_PARAMS = %i(
     organisation
     twilio_number
@@ -14,7 +16,7 @@ class LocationPolicy < ApplicationPolicy
         scope.all
       elsif user.project_manager?
         if user.cita_england_and_wales?
-          scope.where(organisation: %w(cita_e cita_w nicab))
+          scope.where(organisation: CITA_ENGLAND_AND_WALES_ORGANISATIONS)
         else
           scope.where(organisation: user.organisation_slug)
         end
@@ -79,6 +81,13 @@ class LocationPolicy < ApplicationPolicy
   end
 
   def admin_or_organisations_project_manager?
-    admin? || (user.project_manager? && user.organisation_slug == record.organisation)
+    return true if admin?
+    return false unless user.project_manager?
+
+    if user.cita_england_and_wales?
+      CITA_ENGLAND_AND_WALES_ORGANISATIONS.include?(record.organisation)
+    else
+      user.organisation_slug == record.organisation
+    end
   end
 end

--- a/spec/policies/location_policy_spec.rb
+++ b/spec/policies/location_policy_spec.rb
@@ -52,6 +52,15 @@ RSpec.describe LocationPolicy do
       it 'deny access if location organisation does not match users organisation_slug' do
         expect(subject).not_to permit(user, nicab_location)
       end
+
+      context 'when the user is CITA E&W' do
+        let(:user) { build(:user, :cita_e_w, :project_manager) }
+
+        it 'permits for the correct locations' do
+          expect(subject).to permit(user, nicab_location)
+          expect(subject).not_to permit(user, cas_location)
+        end
+      end
     end
 
     context 'when user does not have any specified permissions/roles' do


### PR DESCRIPTION
This was an issue caused by the recent change to scoped access for CITA E&W users. The necessary changes were not included to cover individual access permissions.