### PR TITLE
Ensure locations can be managed correctly by CITA

### DIFF
--- a/app/policies/location_policy.rb
+++ b/app/policies/location_policy.rb
@@ -2,7 +2,6 @@ class LocationPolicy < ApplicationPolicy
   CITA_ENGLAND_AND_WALES_ORGANISATIONS = %w[cita_e cita_w nicab].freeze
 
   ADMIN_PARAMS = %i[
-    organisation
     twilio_number
     online_booking_twilio_number
     online_booking_reply_to
@@ -68,7 +67,7 @@ class LocationPolicy < ApplicationPolicy
       { address: %i[address_line_1 address_line_2 address_line_3 town county postcode] }
     ]
 
-    base_params += [:phone] if creating_new_record? || admin_or_organisations_project_manager?
+    base_params += %i[phone organisation] if creating_new_record? || admin_or_organisations_project_manager?
     base_params += ADMIN_PARAMS if admin?
     base_params += ONLINE_BOOKING_PARAMS if online_booking?
     base_params

--- a/app/views/admin/locations/_form.html.erb
+++ b/app/views/admin/locations/_form.html.erb
@@ -19,13 +19,11 @@
 
 <div class="row">
   <div class="col-md-6">
-    <% if policy(location).admin? %>
-      <div class="form-group <%= 'form-group--error' if f.object.errors[:organisation].any? %>" id="organisation">
-        <%= f.label :organisation %>
-        <%= render 'error', error_messages: location.errors[:organisation] %>
-        <%= f.select :organisation, Location::ORGANISATIONS, { include_blank: true }, class: 'form-control t-organisation text-uppercase' %>
-      </div>
-    <% end %>
+    <div class="form-group <%= 'form-group--error' if f.object.errors[:organisation].any? %>" id="organisation">
+      <%= f.label :organisation %>
+      <%= render 'error', error_messages: location.errors[:organisation] %>
+      <%= f.select :organisation, Location::ORGANISATIONS, { include_blank: true }, class: 'form-control t-organisation text-uppercase' %>
+    </div>
 
     <div class="form-group <%= 'form-group--error' if f.object.errors[:title].any? %>" id="title">
       <%= f.label :title %>

--- a/features/step_definitions/admin/create_location_steps.rb
+++ b/features/step_definitions/admin/create_location_steps.rb
@@ -26,6 +26,7 @@ When(/^I create a new booking location$/) do
   @page = AdminNewLocationPage.new
   @page.load
 
+  @page.organisation.select('nicab')
   @page.location_title.set 'Fun Land'
   @page.booking_hours.set 'Mon-Fri 9am-5pm'
   @page.address_line_1.set 'Fun Lane'

--- a/spec/policies/location_policy_spec.rb
+++ b/spec/policies/location_policy_spec.rb
@@ -104,7 +104,8 @@ RSpec.describe LocationPolicy do
                 postcode
               ]
             },
-            :phone
+            :phone,
+            :organisation
           ]
         )
       end


### PR DESCRIPTION
The organisations were not being set correctly so the project managers were not able to create locations for their organisational divisions.