### PR TITLE
Ensure guider names are present

### DIFF
--- a/app/models/guider.rb
+++ b/app/models/guider.rb
@@ -4,6 +4,8 @@ class Guider < ApplicationRecord
   has_many :guider_assignments
   has_many :locations, through: :guider_assignments
 
+  validates :name, presence: true
+
   def inactive?
     name.to_s.starts_with?(INACTIVE)
   end


### PR DESCRIPTION
This was causing issues downstream in planner when someone was adding and assigning a guider with a blank name.